### PR TITLE
extract rest client creation into own method

### DIFF
--- a/server/services/accreditedProgrammesManageAndDeliverService.ts
+++ b/server/services/accreditedProgrammesManageAndDeliverService.ts
@@ -1,4 +1,3 @@
-import type { SystemToken } from '@hmpps-auth'
 import type { HmppsAuthClient, RestClientBuilderWithoutToken } from '../data'
 import RestClient from '../data/restClient'
 import config, { ApiConfig } from '../config'

--- a/server/services/accreditedProgrammesManageAndDeliverService.ts
+++ b/server/services/accreditedProgrammesManageAndDeliverService.ts
@@ -17,17 +17,19 @@ export interface PaginationParams {
 export default class AccreditedProgrammesManageAndDeliverService {
   constructor(private readonly hmppsAuthClientBuilder: RestClientBuilderWithoutToken<HmppsAuthClient>) {}
 
-  createRestClient = (token: Express.User['token'] | SystemToken): RestClient =>
-    new RestClient(
-      'Accredited Programmes Manage And Deliver Service API Client',
-      config.apis.accreditedProgrammesManageAndDeliverService as ApiConfig,
-      token,
-    )
-
-  async getOpenCaselist(username: Express.User['username']): Promise<Caselist> {
+  async createRestClientFromUsername(username: Express.User['username']): Promise<RestClient> {
     const hmppsAuthClient = this.hmppsAuthClientBuilder()
     const systemToken = await hmppsAuthClient.getSystemClientToken(username)
-    const restClient = this.createRestClient(systemToken)
+
+    return new RestClient(
+      'Accredited Programmes Manage And Deliver Service API Client',
+      config.apis.accreditedProgrammesManageAndDeliverService as ApiConfig,
+      systemToken,
+    )
+  }
+
+  async getOpenCaselist(username: Express.User['username']): Promise<Caselist> {
+    const restClient = await this.createRestClientFromUsername(username)
     return (await restClient.get({
       path: `/pages/caselist/open`,
       headers: { Accept: 'application/json' },
@@ -35,9 +37,7 @@ export default class AccreditedProgrammesManageAndDeliverService {
   }
 
   async getClosedCaselist(username: Express.User['username']): Promise<Caselist> {
-    const hmppsAuthClient = this.hmppsAuthClientBuilder()
-    const systemToken = await hmppsAuthClient.getSystemClientToken(username)
-    const restClient = this.createRestClient(systemToken)
+    const restClient = await this.createRestClientFromUsername(username)
     return (await restClient.get({
       path: `/pages/caselist/closed`,
       headers: { Accept: 'application/json' },
@@ -45,9 +45,7 @@ export default class AccreditedProgrammesManageAndDeliverService {
   }
 
   async getPersonalDetails(username: Express.User['username'], id: string): Promise<PersonalDetails> {
-    const hmppsAuthClient = this.hmppsAuthClientBuilder()
-    const systemToken = await hmppsAuthClient.getSystemClientToken(username)
-    const restClient = this.createRestClient(systemToken)
+    const restClient = await this.createRestClientFromUsername(username)
     return (await restClient.get({
       path: `/referral/${id}`,
       headers: { Accept: 'application/json' },


### PR DESCRIPTION
Move creation of rest client to a re-useable method.