### PR TITLE
feat(pipeline.yaml): Add the Slack notification for approving a deployment

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -87,6 +87,97 @@ jobs:
     with:
       environment: 'preprod'
       app_version: '${{ needs.build.outputs.app_version }}'
+  notify_for_prod_approval:
+    needs: 
+      - build
+      - deploy_preprod
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Get PR information 
+        id: pr-info 
+        run: |
+          # Get the commit SHA from the last commit
+          # See https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_run
+          COMMIT_SHA="${{ github.sha }}"
+
+          # Get the first line of the most recent commit message 
+          COMMIT_MESSAGE=$(git log -1 --pretty=%B "$COMMIT_SHA" | head -n 1)
+          echo "commit_message=$COMMIT_MESSAGE" >> $GITHUB_OUTPUT
+
+          # Use the GitHub CLI to get the PR associated with this commit, its number, title, and author 
+          PR_INFO=$(gh pr list --search "$COMMIT_SHA" --json number,title,author --jq '.[0]')
+          PR_NUMBER=$(echo "$PR_INFO" | jq -r '.number')
+          PR_TITLE=$(echo "$PR_INFO" | jq -r '.title')
+
+          # The author is the author of the commit 
+          PR_AUTHOR="${{ github.actor}}"
+
+          echo "pr_author=$PR_AUTHOR" >> $GITHUB_OUTPUT
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "pr_title=$PR_TITLE" >> $GITHUB_OUTPUT
+        env: 
+          GH_TOKEN: ${{ github.token }}
+      - name: Map GitHub user to Slack ID 
+        id: slack-mapping
+        run: |
+          # Parse the GitHub to Slack mapping (expecting JSON format)
+          GITHUB_USERNAME="${{ github.actor }}"
+          USER_MAPPING='${{ vars.GH_TO_SLACK_MAPPING }}'
+          
+          if [[ "$USER_MAPPING" == "" ]]; then
+            echo "Warning: GH_TO_SLACK_MAPPING not configured"
+            SLACK_USER_ID="unknown"
+          else
+            SLACK_USER_ID=$(echo "$USER_MAPPING" | jq -r --arg user "$GITHUB_USERNAME" '.[$user] // "unknown"')
+          fi
+          
+          echo "slack_user_id=$SLACK_USER_ID" >> $GITHUB_OUTPUT
+      - name: Generate the Approval link 
+        id: approval-link
+        run: |
+          # Create link to the workflow that needs approval 
+          APPROVAL_LINK="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          echo "Approval Link: $APPROVAL_LINK"
+          echo "approval_link=$APPROVAL_LINK" >> $GITHUB_OUTPUT
+      - name: Send Slack notification 
+        run: |
+          # Prepare the JSON payload
+          PAYLOAD=$(jq -n \
+            --arg link "${{ steps.approval-link.outputs.approval_link }}" \
+            --arg slack_user "${{ steps.slack-mapping.outputs.slack_user_id }}" \
+            --arg pr_name "${{ steps.pr-info.outputs.pr_title }}" \
+            --arg pr_number "${{ steps.pr-info.outputs.pr_number }}" \
+            --arg github_user "${{ github.actor }}" \
+            --arg repo "${{ github.repository }}" \
+            '{
+              link_to_approval_step: $link,
+              developer_to_tag_slack_user_id: $slack_user,
+              human_readable_pr_name: $pr_name,
+              pr_number: $pr_number,
+              github_username: $github_user,
+              repository: $repo,
+              timestamp: now
+            }')
+          
+          # Send the webhook request
+          curl -X POST \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
+            "${{ secrets.SLACK_WEBHOOK_URL }}" \
+            --fail \
+            --show-error \
+            --silent
+            
+          if [[ $? -eq 0 ]]; then
+            echo "✅ Slack notification sent successfully"
+          else
+            echo "❌ Failed to send Slack notification"
+            echo "Please check the GH_TO_SLACK_MAPPING variable for user "${{ github.actor }}" and SLACK_WEBHOOK_URL secret."
+            exit 1
+          fi
   deploy_prod:
     name: Deploy to production environment
     needs:


### PR DESCRIPTION
This commit introduces a series of steps in the pipeline (`test -> build
-> deploy`) GitHub action which gathers some basic information about the
(previously-merged) PR, and sends a HTTP POST request to a known Slack
URL.

This results in a message being published to the all-devs channel on manage-and-deliver.

We want to maintain a deployment gate / manual approve step in our deploy-to-production step.

However, it is non-obvious when a deployment gets to the point where it is blocked by a manual approve.  This PR builds in some notification infrastructure for the humans who build and maintain the codebase.

We want to create a public, accessible, and push-based alert system to let developers know that their deployment is ready for testing.

We want to do this to reduce the time spent between a PR being merged to `main` and a deployment going out.

Building a custom Slack Workflow URL appears to be the best way to achieve this.

This PR relies on a Slack "Workflow" that I (TJWC) have created that takes in the following payload:

```ts
{
              link_to_approval_step: "https://www.github.com/...",
              developer_to_tag_slack_user_id: "slack_user_id",
              human_readable_pr_name: "Some PR name",
              pr_number: "65",
              github_username: "thomaswilsonxyz",
              repository: "ministryofjustice/hmpps-accredited-programmes-manage-and-deliver-api",
              timestamp: "2025-07-29T16:07+01:00"
}
```

This is sent via `curl` in a step in the pipeline.

It also relies on a mapping of GitHub usernames to Slack usernames, which is managed as an Environment Variable in this repo.

The URL where we actually send this information needs to remain private, and is stored in the `SLACK_WEBHOOK_URL` secret in the repo.

As developers come/go from the team, we'll need to update this environment variable.
