### PR TITLE
APG-1167: Filter ethnicity field if it's not present

### DIFF
--- a/script/generateApiTypes/manageAndDeliverApiTypes
+++ b/script/generateApiTypes/manageAndDeliverApiTypes
@@ -4,3 +4,6 @@
 #
 
 npx openapi-typescript https://accredited-programmes-manage-and-deliver-api-dev.hmpps.service.justice.gov.uk/v3/api-docs --output ./server/@types/manageAndDeliverApi/imported/index.d.ts
+
+# Uncomment to point to local api container for types (useful if doing implementing full feature work).
+# npx openapi-typescript http://localhost:8080/v3/api-docs --output ./server/@types/manageAndDeliverApi/imported/index.d.ts

--- a/server/referralDetails/personalDetailsPresenter.ts
+++ b/server/referralDetails/personalDetailsPresenter.ts
@@ -55,6 +55,6 @@ export default class PersonalDetailsPresenter extends ReferralDetailsPresenter {
         key: 'Probation delivery unit',
         lines: [this.personalDetails.probationDeliveryUnit],
       },
-    ]
+    ].filter(item => item.lines.every(line => line !== null))
   }
 }

--- a/wiremock_mappings/delius.json
+++ b/wiremock_mappings/delius.json
@@ -82,15 +82,10 @@
           "crn": "X718255",
           "name": {
             "forename": "David",
-            "middleNames": "Alex",
             "surname": "Clarke"
           },
           "dateOfBirth": "1981-04-15",
           "age": 48,
-          "ethnicity": {
-            "code": "W1",
-            "description": "White"
-          },
           "sex": {
             "code": "M",
             "description": "Male"


### PR DESCRIPTION
We have discovered that ethnicity can be null as part of the nDelius personal details response. This PR ensures that we hide that field if `ethnicity` is not present.

<img width="779" height="383" alt="image" src="https://github.com/user-attachments/assets/01aec5a6-d887-44ff-81cb-d2e7bd1bb621" />
