### PR TITLE
Small tweaks to the availability journey

### DIFF
--- a/server/referralDetails/addAvailability/addAvailabilityPresenter.test.ts
+++ b/server/referralDetails/addAvailability/addAvailabilityPresenter.test.ts
@@ -4,6 +4,10 @@ import AddAvailabilityPresenter from './addAvailabilityPresenter'
 import personalDetailsFactory from '../../testutils/factories/personalDetailsFactory'
 import availabilityFactory from '../../testutils/factories/availabilityFactory'
 
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
 describe(`generateCheckboxItems.`, () => {
   it('if no availability id is present, the url should be for adding a new availability', () => {
     const personalDetails = personalDetailsFactory.build()
@@ -55,6 +59,89 @@ describe(`generateCheckboxItems.`, () => {
         value: 'Mondays-evening',
         text: 'evening',
         checked: false,
+      },
+    ])
+  })
+
+  it('should generate the checkboxes correctly when re-rendering the page after an error', () => {
+    const availabilities = [
+      {
+        label: 'Mondays' as DailyAvailabilityModel['label'],
+        slots: [
+          { label: 'daytime', value: false },
+          { label: 'evening', value: false },
+        ],
+      },
+      {
+        label: 'Tuesdays' as DailyAvailabilityModel['label'],
+        slots: [
+          { label: 'daytime', value: false },
+          { label: 'evening', value: false },
+        ],
+      },
+      {
+        label: 'Wednesdays' as DailyAvailabilityModel['label'],
+        slots: [
+          { label: 'daytime', value: false },
+          { label: 'evening', value: false },
+        ],
+      },
+    ]
+    const personalDetails = personalDetailsFactory.build()
+    const availability = availabilityFactory.defaultAvailability().build({ availabilities })
+
+    const presenter = new AddAvailabilityPresenter(personalDetails, null, null, null, availability, null)
+
+    const mockFields = jest.spyOn(presenter, 'fields', 'get')
+    mockFields.mockReturnValue({
+      availabilityCheckboxes: {
+        value: 'Mondays-daytime,Tuesdays-evening,Wednesdays-daytime,Wednesdays-evening',
+        errorMessage: null,
+      },
+      otherDetailsTextArea: { value: '', errorMessage: null },
+      endDateRequired: { value: '', errorMessage: 'This is required' },
+      endDate: { value: '', errorMessage: null },
+    })
+
+    expect(presenter.generateCheckboxItems()).toEqual([
+      {
+        divider: 'Mondays',
+      },
+      {
+        value: 'Mondays-daytime',
+        text: 'daytime',
+        checked: true,
+      },
+      {
+        value: 'Mondays-evening',
+        text: 'evening',
+        checked: false,
+      },
+      {
+        divider: 'Tuesdays',
+      },
+      {
+        value: 'Tuesdays-daytime',
+        text: 'daytime',
+        checked: false,
+      },
+      {
+        value: 'Tuesdays-evening',
+        text: 'evening',
+        checked: true,
+      },
+      {
+        divider: 'Wednesdays',
+      },
+      {
+        value: 'Wednesdays-daytime',
+        text: 'daytime',
+        checked: true,
+      },
+      {
+        value: 'Wednesdays-evening',
+        text: 'evening',
+        checked: true,
       },
     ])
   })

--- a/server/referralDetails/addAvailability/addAvailabilityPresenter.ts
+++ b/server/referralDetails/addAvailability/addAvailabilityPresenter.ts
@@ -38,6 +38,31 @@ export default class AddAvailabilityPresenter {
   }
 
   generateCheckboxItems() {
+    // Remember the values selected if the page is re-created after form errors
+    if (this.fields.availabilityCheckboxes.value !== '') {
+      const selections = this.fields.availabilityCheckboxes.value.split(',').map(s => s.trim())
+      selections.forEach(selection => {
+        const [dayLabel, slotLabel] = selection.split('-')
+
+        // Find the matching day
+        const dayIndex = this.availability.availabilities.findIndex(
+          day => day.label.toLowerCase() === dayLabel.toLowerCase(),
+        )
+
+        if (dayIndex !== -1) {
+          // Find the matching slot within that day
+          const slotIndex = this.availability.availabilities[dayIndex].slots.findIndex(
+            slot => slot.label.toLowerCase() === slotLabel.toLowerCase(),
+          )
+
+          if (slotIndex !== -1) {
+            // Set the value to true
+            this.availability.availabilities[dayIndex].slots[slotIndex].value = true
+          }
+        }
+      })
+    }
+    console.log(this.availability)
     const checkboxes: { divider?: string; value?: string; text?: string; checked?: boolean }[] = []
     this.availability.availabilities.forEach(day => {
       checkboxes.push({

--- a/server/referralDetails/availabilityPresenter.test.ts
+++ b/server/referralDetails/availabilityPresenter.test.ts
@@ -82,8 +82,6 @@ describe(`getAvailabilityTableArgs.`, () => {
     }
     const presenter = new AvailabilityPresenter(referralDetails, 'availability', '12345', availability)
     expect(presenter.getAvailabilityTableArgs()).toEqual({
-      caption: 'Dates and amounts',
-      captionClasses: 'govuk-table__caption--m',
       firstCellIsHeader: true,
       head: [{ text: 'Day' }, { text: 'Daytime' }, { text: 'Evening' }, { text: 'Nighttime' }],
       rows: [

--- a/server/referralDetails/availabilityPresenter.ts
+++ b/server/referralDetails/availabilityPresenter.ts
@@ -47,8 +47,6 @@ export default class AvailabilityPresenter extends ReferralDetailsPresenter {
     })
 
     return {
-      caption: 'Dates and amounts',
-      captionClasses: 'govuk-table__caption--m',
       firstCellIsHeader: true,
       head: headings,
       rows,

--- a/server/views/referralDetails/availability.njk
+++ b/server/views/referralDetails/availability.njk
@@ -12,9 +12,15 @@
       {{ govukInsetText(importFromDeliusText) }}
       <p>This is {{ presenter.details.personName }}'s general availability to attend an Accredited Programme.</p>
       {{ govukTable(availabilityTableArgs) }}
+
+      {% if presenter.availability.otherDetails !== '' %}
+        <h3 class="govuk-heading-s">Other availability details</h3>
+        <p class="govuk-body">{{ presenter.availability.otherDetails }}</p>
+      {% endif %}
    {% else %}
       <p>No availability details added for {{ presenter.details.personName }}</p>
    {% endif %}
 
    {{ govukButton(availabilityButtonArgs) }}
-</div>
+
+ </div>


### PR DESCRIPTION
A few tweaks after a review of the journey by Flora - 

1. Playback the free text field value on the availability page
2. Remove 'Dates and amounts' heading
3. If the user encounters an error on the form page then the checkboxes they had selected will now be persisted instead of being cleared