### PR TITLE
Update referralStatus to status in case list filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,13 @@ And then, to build the assets and start the app with esbuild:
 
 `npm run start:dev`
 
+#### Updating the API for docker
+
+NB: if issues are encountered with starting the M&D API in docker, or to force a fresh docker image re-build following API updates,
+use the following command prior to running `docker compose up` :
+
+`docker-compose build --no-cache hmpps-accredited-programmes-manage-and-deliver-api`
+
 ### Logging in with a test user
 
 Once the application is running you should then be able to login with:

--- a/server/caselist/CaseListFilterParams.ts
+++ b/server/caselist/CaseListFilterParams.ts
@@ -1,5 +1,5 @@
 export interface CaselistFilterParams {
   crnOrPersonName?: string
-  referralStatus?: string
+  status?: string
   cohort?: string
 }

--- a/server/caselist/caseListUtils.ts
+++ b/server/caselist/caseListUtils.ts
@@ -6,67 +6,67 @@ export default class CaselistUtils {
 
   static referralStatus = [
     {
-      value: 'referral-submitted',
+      value: 'REFERRAL_SUBMITTED',
       text: 'Referral submitted',
     },
     {
-      value: 'referral-submitted-hold',
+      value: 'ON_HOLD_REFERRAL_SUBMITTED',
       text: 'On hold - referral submitted',
     },
     {
-      value: 'court-order',
+      value: 'COURT_ORDER',
       text: 'Court order',
     },
     {
-      value: 'returned-court',
+      value: 'RETURNED_TO_COURT',
       text: 'Returned to court',
     },
     {
-      value: 'awaiting-assessment',
+      value: 'AWAITING_ASSESSMENT',
       text: 'Awaiting assessment',
     },
     {
-      value: 'awaiting-assessment-hold',
+      value: 'ON_HOLD_AWAITING_ASSESSMENT',
       text: 'On hold - awaiting assessment',
     },
     {
-      value: 'assessment-started',
+      value: 'ASSESSMENT_STARTED',
       text: 'Assessment started',
     },
     {
-      value: 'assessment-started-hold',
+      value: 'ON_HOLD_ASSESSMENT_STARTED',
       text: 'On hold - assessment started',
     },
     {
-      value: 'assessed-suitable',
+      value: 'ASSESSED_SUITABLE',
       text: 'Assessed as suitable',
     },
     {
-      value: 'suitable-not-ready',
+      value: 'SUITABLE_NOT_READY',
       text: 'Suitable but not ready',
     },
     {
-      value: 'on-programme',
+      value: 'ON_PROGRAMME',
       text: 'On programme',
     },
     {
-      value: 'not-eligible',
+      value: 'NOT_ELIGIBLE',
       text: 'Not eligible',
     },
     {
-      value: 'not-suitable',
+      value: 'NOT_SUITABLE',
       text: 'Not suitable',
     },
     {
-      value: 'withdrawn',
+      value: 'WITHDRAWN',
       text: 'Withdrawn',
     },
     {
-      value: 'deselected',
+      value: 'DESELECTED',
       text: 'Deselected',
     },
     {
-      value: 'programme-complete',
+      value: 'PROGRAMME_COMPLETE',
       text: 'Programme complete',
     },
   ]

--- a/server/caselist/caselistFilter.test.ts
+++ b/server/caselist/caselistFilter.test.ts
@@ -12,7 +12,7 @@ describe(CaselistFilter, () => {
 
       const filter = CaselistFilter.fromRequest({ query } as unknown as Request)
 
-      expect(filter.referralStatus).toEqual('referral-submitted')
+      expect(filter.status).toEqual('referral-submitted')
       expect(filter.cohort).toEqual('sexual-offence')
       expect(filter.crnOrPersonName).toEqual('Building')
     })
@@ -22,7 +22,7 @@ describe(CaselistFilter, () => {
     describe('No params', () => {
       it('correctly expects fields to be undefined if no type passed', () => {
         const filter = new CaselistFilter()
-        expect(filter.referralStatus).toBeUndefined()
+        expect(filter.status).toBeUndefined()
         expect(filter.cohort).toBeUndefined()
         expect(filter.crnOrPersonName).toBeUndefined()
       })
@@ -31,9 +31,9 @@ describe(CaselistFilter, () => {
     describe('referralStatus', () => {
       it('correctly sets referralStatus if only one type is passed', () => {
         const filter = new CaselistFilter()
-        filter.referralStatus = 'referral-submitted-hold'
+        filter.status = 'referral-submitted-hold'
 
-        expect(filter.params.referralStatus).toEqual('referral-submitted-hold')
+        expect(filter.params.status).toEqual('referral-submitted-hold')
       })
 
       it('correctly sets cohort if only one type is passed', () => {

--- a/server/caselist/caselistFilter.ts
+++ b/server/caselist/caselistFilter.ts
@@ -2,7 +2,7 @@ import { Request } from 'express'
 import { CaselistFilterParams } from './CaseListFilterParams'
 
 export default class CaselistFilter {
-  referralStatus: string | undefined
+  status: string | undefined
 
   cohort: string | undefined
 
@@ -10,7 +10,7 @@ export default class CaselistFilter {
 
   static fromRequest(request: Request): CaselistFilter {
     const filter = new CaselistFilter()
-    filter.referralStatus = request.query.referralStatus as string | undefined
+    filter.status = request.query.status as string | undefined
     filter.cohort = request.query.cohort as string | undefined
     filter.crnOrPersonName = request.query.crnOrPersonName as string | undefined
     return filter
@@ -19,8 +19,8 @@ export default class CaselistFilter {
   get params(): CaselistFilterParams {
     const params: CaselistFilterParams = {}
 
-    if (this.referralStatus !== undefined) {
-      params.referralStatus = this.referralStatus
+    if (this.status !== undefined) {
+      params.status = this.status
     }
     if (this.cohort !== undefined) {
       params.cohort = this.cohort

--- a/server/caselist/caselistPresenter.test.ts
+++ b/server/caselist/caselistPresenter.test.ts
@@ -11,7 +11,7 @@ describe(`filters.`, () => {
     it('should return the correct filter pane object for filters supplied', () => {
       const testObject = {
         filter: {
-          referralStatus: 'awaiting-assessment',
+          status: 'awaiting-assessment',
           cohort: 'sexual-offence',
           crnOrPersonName: 'Name',
         } as CaselistFilter,
@@ -69,7 +69,7 @@ describe(`filters.`, () => {
 
     it('should return the correct filter pane object when no filters supplied', () => {
       const testObject = {
-        filter: { referralStatus: undefined, cohort: undefined, crnOrPersonName: undefined } as CaselistFilter,
+        filter: { status: undefined, cohort: undefined, crnOrPersonName: undefined } as CaselistFilter,
       }
       const referralCaseListItem = referralCaseListItemFactory.build()
       const referralCaseListItemPage: Page<ReferralCaseListItem> = pageFactory
@@ -83,7 +83,7 @@ describe(`filters.`, () => {
   describe('generateSelectValues', () => {
     it('should generate the correct select values', () => {
       const testObject = {
-        filter: { referralStatus: undefined, cohort: undefined, crnOrPersonName: undefined } as CaselistFilter,
+        filter: { status: undefined, cohort: undefined, crnOrPersonName: undefined } as CaselistFilter,
       }
       const referralCaseListItem = referralCaseListItemFactory.build()
       const referralCaseListItemPage: Page<ReferralCaseListItem> = pageFactory
@@ -95,7 +95,7 @@ describe(`filters.`, () => {
         { value: 'general-offence', text: 'General Offence' },
         { value: 'sexual-offence', text: 'Sexual Offence' },
       ]
-      expect(presenter.generateSelectValues(valuesToAddToSelect, testObject.filter.referralStatus)).toEqual([
+      expect(presenter.generateSelectValues(valuesToAddToSelect, testObject.filter.status)).toEqual([
         { text: 'Select', value: '' },
         { selected: false, text: 'General Offence', value: 'general-offence' },
         { selected: false, text: 'Sexual Offence', value: 'sexual-offence' },
@@ -104,7 +104,7 @@ describe(`filters.`, () => {
 
     it('should generate just select value when no values provided', () => {
       const testObject = {
-        filter: { referralStatus: undefined, cohort: undefined, crnOrPersonName: undefined } as CaselistFilter,
+        filter: { status: undefined, cohort: undefined, crnOrPersonName: undefined } as CaselistFilter,
       }
       const referralCaseListItem = referralCaseListItemFactory.build()
       const referralCaseListItemPage: Page<ReferralCaseListItem> = pageFactory
@@ -113,7 +113,7 @@ describe(`filters.`, () => {
       const presenter = new CaselistPresenter(1, referralCaseListItemPage, testObject.filter, '', true)
 
       const valuesToAddToSelect: { value: string; text: string }[] = []
-      expect(presenter.generateSelectValues(valuesToAddToSelect, testObject.filter.referralStatus)).toEqual([
+      expect(presenter.generateSelectValues(valuesToAddToSelect, testObject.filter.status)).toEqual([
         { text: 'Select', value: '' },
       ])
     })
@@ -123,7 +123,7 @@ describe(`filters.`, () => {
     it('should generate correct filters base on input params', () => {
       const testObject = {
         filter: {
-          referralStatus: 'not-eligible',
+          status: 'not-eligible',
           cohort: 'general-offence',
           crnOrPersonName: 'Some Name',
         } as CaselistFilter,
@@ -143,7 +143,7 @@ describe(`filters.`, () => {
 
     it('should not generate selected filters when there are none on the params', () => {
       const testObject = {
-        filter: { referralStatus: undefined, cohort: undefined, crnOrPersonName: undefined } as CaselistFilter,
+        filter: { status: undefined, cohort: undefined, crnOrPersonName: undefined } as CaselistFilter,
       }
       const referralCaseListItem = referralCaseListItemFactory.build()
       const referralCaseListItemPage: Page<ReferralCaseListItem> = pageFactory

--- a/server/caselist/caselistPresenter.ts
+++ b/server/caselist/caselistPresenter.ts
@@ -109,13 +109,13 @@ export default class CaselistPresenter {
 
   searchByStatusArgs(): SelectArgs {
     return {
-      id: 'referralStatus',
-      name: 'referralStatus',
+      id: 'status',
+      name: 'status',
       label: {
         text: 'Referral status',
         classes: 'govuk-label--s',
       },
-      items: this.generateSelectValues(CaselistUtils.referralStatus, this.filter.referralStatus),
+      items: this.generateSelectValues(CaselistUtils.referralStatus, this.filter.status),
     }
   }
 
@@ -157,11 +157,11 @@ export default class CaselistPresenter {
   generateSelectedFilters() {
     const selectedFilters = []
 
-    if (this.filter.referralStatus) {
+    if (this.filter.status) {
       const searchParams = new URLSearchParams(this.params)
-      searchParams.delete('referralStatus')
+      searchParams.delete('status')
       const paramAttributes = CaselistUtils.referralStatus.filter(
-        referralStatus => referralStatus.value === this.filter.referralStatus,
+        referralStatus => referralStatus.value === this.filter.status,
       )
       selectedFilters.push({
         heading: {
@@ -169,7 +169,7 @@ export default class CaselistPresenter {
         },
         items: [
           {
-            // href: `/interventions/${this.setting}${searchParams.size === 0 ? '' : `?${searchParams.toString()}`}`,
+            href: `/pdu/${this.openOrClosedUrl}${searchParams.size === 0 ? '' : `?${searchParams.toString()}`}`,
             text: paramAttributes[0].text,
           },
         ],


### PR DESCRIPTION
* Updated the `referralStatus` key to `status` across all case list filters as part of standardizing key naming conventions.
* Replaced status values with corresponding uppercase constants for consistency and clarity.
* Updated README file with workaround for API docker caching issue