### PR TITLE
Add relationships page to risks and needs section

### DIFF
--- a/server/@types/manageAndDeliverApi/imported/index.d.ts
+++ b/server/@types/manageAndDeliverApi/imported/index.d.ts
@@ -104,6 +104,23 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/risks-and-needs/{crn}/relationships': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Retrieve a person's relationship details as held in Oasys */
+    get: operations['getRelationships']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/risks-and-needs/{crn}/learning-needs': {
     parameters: {
       query?: never
@@ -622,6 +639,37 @@ export interface components {
        * @enum {string}
        */
       scoreLevel?: 'LOW' | 'MEDIUM' | 'HIGH'
+    }
+    Relationships: {
+      /**
+       * Format: date
+       * @example 1
+       */
+      assessmentCompleted?: string
+      /** @example true */
+      dvEvidence?: boolean
+      /** @example false */
+      victimFormerPartner?: boolean
+      /** @example true */
+      victimFamilyMember?: boolean
+      /** @example false */
+      victimOfPartnerFamily?: boolean
+      /** @example true */
+      perpOfPartnerOrFamily?: boolean
+      /** @example This person has a history of domestic violence */
+      relIssuesDetails?: string
+      /** @example 0-No problems */
+      relCloseFamily?: string
+      /** @example Not in a relationship */
+      relCurrRelationshipStatus?: string
+      /** @example 2-Significant problems */
+      prevCloseRelationships?: string
+      /** @example 0-No problems */
+      emotionalCongruence?: string
+      /** @example 0-No problems */
+      relationshipWithPartner?: string
+      /** @example No */
+      prevOrCurrentDomesticAbuse?: string
     }
     LearningNeeds: {
       /**
@@ -1354,6 +1402,65 @@ export interface operations {
         }
       }
       /** @description The risks and needs information does not exist for the CRN provided. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  getRelationships: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description CRN */
+        crn: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Relationship details held by Oasys */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Relationships']
+        }
+      }
+      /** @description Invalid code format. Expected format for CRN: X718255. */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': string
+        }
+      }
+      /** @description The request was unauthorised */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden.  The client is not authorised to access this referral. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description The relationship information does not exist for the CRN provided. */
       404: {
         headers: {
           [name: string]: unknown

--- a/server/@types/manageAndDeliverApi/index.d.ts
+++ b/server/@types/manageAndDeliverApi/index.d.ts
@@ -14,6 +14,7 @@ type LearningNeeds = components['schemas']['LearningNeeds']
 type RoshAnalysis = components['schemas']['RoshAnalysis']
 type PniScore = components['schemas']['PniScore']
 type Health = components['schemas']['Health']
+type Relationships = components['schemas']['Relationships']
 
 export type {
   Availability,
@@ -30,4 +31,5 @@ export type {
   PniScore,
   LearningNeeds,
   Health,
+  Relationships,
 }

--- a/server/risksAndNeeds/learningNeeds/learningNeedsPresenter.ts
+++ b/server/risksAndNeeds/learningNeeds/learningNeedsPresenter.ts
@@ -1,6 +1,7 @@
 import { LearningNeeds } from '@manage-and-deliver-api'
 import RisksAndNeedsPresenter from '../risksAndNeedsPresenter'
 import { SummaryListItem } from '../../utils/summaryList'
+import PresenterUtils from '../../utils/presenterUtils'
 
 export default class LearningNeedsPresenter extends RisksAndNeedsPresenter {
   constructor(
@@ -17,7 +18,7 @@ export default class LearningNeedsPresenter extends RisksAndNeedsPresenter {
     return [
       {
         key: '3.3 - Currently of no fixed abode or in transient accommodation',
-        lines: [`${LearningNeedsPresenter.yesOrNo(this.learningNeeds.noFixedAbodeOrTransient)}`],
+        lines: [`${PresenterUtils.yesOrNo(this.learningNeeds.noFixedAbodeOrTransient)}`],
       },
       {
         key: '4.4 - Work related skills',
@@ -37,10 +38,6 @@ export default class LearningNeedsPresenter extends RisksAndNeedsPresenter {
         lines: [`${this.learningNeeds.qualifications}`],
       },
     ]
-  }
-
-  static yesOrNo(value?: boolean): 'No' | 'Yes' {
-    return value ? 'Yes' : 'No'
   }
 
   learningNeedsScoreSummaryList(): SummaryListItem[] {

--- a/server/risksAndNeeds/relationships/relationshipsPresenter.ts
+++ b/server/risksAndNeeds/relationships/relationshipsPresenter.ts
@@ -1,10 +1,43 @@
+import { Relationships } from '@manage-and-deliver-api'
 import RisksAndNeedsPresenter from '../risksAndNeedsPresenter'
+import { SummaryListItem } from '../../utils/summaryList'
+import PresenterUtils from '../../utils/presenterUtils'
 
 export default class RelationshipsPresenter extends RisksAndNeedsPresenter {
   constructor(
     readonly subNavValue: string,
     readonly referralId: string,
+    readonly relationships: Relationships,
   ) {
     super(subNavValue, referralId)
+  }
+
+  relationshipsSummaryList(): SummaryListItem[] {
+    return [
+      {
+        key: '6.7 - Evidence of domestic violence / partner abuse',
+        lines: [`${PresenterUtils.yesOrNo(this.relationships.dvEvidence)}`],
+      },
+      {
+        key: '6.7.1.1 - Is the victim a current or former partner?',
+        lines: [`${PresenterUtils.yesOrNo(this.relationships.victimFormerPartner)}`],
+      },
+      {
+        key: '6.7.1.2 - Is the victim a family member?',
+        lines: [`${PresenterUtils.yesOrNo(this.relationships.victimFamilyMember)}`],
+      },
+      {
+        key: '6.7.2.1 - Is the perpetrator a victim of partner or family abuse?',
+        lines: [`${PresenterUtils.yesOrNo(this.relationships.victimOfPartnerFamily)}`],
+      },
+      {
+        key: '6.7.2.2 - Are they the perpetrator of partner or family abuse?',
+        lines: [`${PresenterUtils.yesOrNo(this.relationships.perpOfPartnerOrFamily)}`],
+      },
+    ]
+  }
+
+  relationshipsIssuesDetails(): string {
+    return this.relationships.relIssuesDetails
   }
 }

--- a/server/risksAndNeeds/relationships/relationshipsView.ts
+++ b/server/risksAndNeeds/relationships/relationshipsView.ts
@@ -1,13 +1,40 @@
 import RelationshipsPresenter from './relationshipsPresenter'
+import { InsetTextArgs, SummaryListArgs } from '../../utils/govukFrontendTypes'
+import ViewUtils from '../../utils/viewUtils'
 
 export default class RelationshipsView {
   constructor(private readonly presenter: RelationshipsPresenter) {}
+
+  get domesticViolenceSummaryList(): SummaryListArgs {
+    return {
+      ...ViewUtils.summaryListArgsWithSummaryCard(this.presenter.relationshipsSummaryList(), '6.7 - Domestic violence'),
+    }
+  }
+
+  get relationshipIssuesDetails(): string {
+    return this.presenter.relationshipsIssuesDetails()
+  }
+
+  get relationshipIssuesDetailsHeading(): string {
+    return 'Relationship issues affecting risk of offending or harm'
+  }
+
+  get assessmentCompletedText(): InsetTextArgs {
+    return {
+      text: `Assessment completed ${this.presenter.relationships.assessmentCompleted}`,
+      classes: 'govuk-!-margin-top-0',
+    }
+  }
 
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'risksAndNeeds/risksAndNeeds',
       {
         presenter: this.presenter,
+        relationshipIssuesDetails: this.relationshipIssuesDetails,
+        relationshipIssuesDetailsHeading: this.relationshipIssuesDetailsHeading,
+        domesticViolenceSummaryList: this.domesticViolenceSummaryList,
+        assessmentCompletedText: this.assessmentCompletedText,
       },
     ]
   }

--- a/server/risksAndNeeds/risksAndNeedsController.ts
+++ b/server/risksAndNeeds/risksAndNeedsController.ts
@@ -23,12 +23,12 @@ import OffenceAnalysisPresenter from './offenceAnalysis/offenceAnalysisPresenter
 import OffenceAnalysisView from './offenceAnalysis/offenceAnalysisView'
 import RisksAndAlertsPresenter from './risksAndAlerts/risksAndAlertsPresenter'
 import RisksAndAlertsView from './risksAndAlerts/risksAndAlertsView'
-import RisksAndNeedsPresenter from './risksAndNeedsPresenter'
-import RisksAndNeedsView from './risksAndNeedsView'
 import RoshAnalysisPresenter from './roshAnalysis/roshAnalysisPresenter'
 import RoshAnalysisView from './roshAnalysis/roshAnalysisView'
 import ThinkingAndBehavingPresenter from './thinkingAndBehaving/thinkingAndBehavingPresenter'
 import ThinkingAndBehavingView from './thinkingAndBehaving/thinkingAndBehavingView'
+import RelationshipsPresenter from './relationships/relationshipsPresenter'
+import RelationshipsView from './relationships/relationshipsView'
 
 export default class RisksAndNeedsController {
   constructor(
@@ -100,9 +100,13 @@ export default class RisksAndNeedsController {
     const subNavValue = 'relationships'
 
     const sharedReferralDetailsData = await this.getSharedPageData(referralId, username)
+    const relationships = await this.accreditedProgrammesManageAndDeliverService.getRelationships(
+      username,
+      sharedReferralDetailsData.crn,
+    )
 
-    const presenter = new RisksAndNeedsPresenter(subNavValue, referralId)
-    const view = new RisksAndNeedsView(presenter)
+    const presenter = new RelationshipsPresenter(subNavValue, referralId, relationships)
+    const view = new RelationshipsView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, sharedReferralDetailsData)
   }

--- a/server/services/accreditedProgrammesManageAndDeliverService.ts
+++ b/server/services/accreditedProgrammesManageAndDeliverService.ts
@@ -11,6 +11,7 @@ import {
   PniScore,
   UpdateAvailability,
   Health,
+  Relationships,
 } from '@manage-and-deliver-api'
 import { CaselistFilterParams } from '../caselist/CaseListFilterParams'
 import config, { ApiConfig } from '../config'
@@ -107,6 +108,14 @@ export default class AccreditedProgrammesManageAndDeliverService {
       path: `/risks-and-needs/${crn}/learning-needs`,
       headers: { Accept: 'application/json' },
     })) as LearningNeeds
+  }
+
+  async getRelationships(username: Express.User['username'], crn: string): Promise<Relationships> {
+    const restClient = await this.createRestClientFromUsername(username)
+    return (await restClient.get({
+      path: `/risks-and-needs/${crn}/relationships`,
+      headers: { Accept: 'application/json' },
+    })) as Relationships
   }
 
   async getHealth(username: Express.User['username'], crn: string): Promise<Health> {

--- a/server/testutils/factories/risksAndNeeds/relationshipsFactory.ts
+++ b/server/testutils/factories/risksAndNeeds/relationshipsFactory.ts
@@ -1,0 +1,15 @@
+import { Relationships } from '@manage-and-deliver-api'
+import { Factory } from 'fishery'
+
+class RelationshipsFactory extends Factory<Relationships> {}
+
+export default RelationshipsFactory.define(() => ({
+  assessmentCompleted: '23 August 2025',
+  dvEvidence: true,
+  victimFormerPartner: true,
+  victimFamilyMember: false,
+  victimOfPartnerFamily: false,
+  perpOfPartnerOrFamily: true,
+  relIssuesDetails:
+    'The person has a history of domestic violence and controlling behavior in relationships. They have difficulty maintaining healthy relationships and often resort to aggressive tactics when conflicts arise.',
+}))

--- a/server/utils/presenterUtils.ts
+++ b/server/utils/presenterUtils.ts
@@ -74,4 +74,11 @@ export default class PresenterUtils {
 
     return !!error.errors.find(subError => subError.formFields.includes(field))
   }
+
+  static yesOrNo(value?: boolean | null): 'No' | 'Yes' | 'Unknown' {
+    if (value === null || value === undefined) {
+      return 'Unknown'
+    }
+    return value ? 'Yes' : 'No'
+  }
 }

--- a/server/views/partials/keylessSummaryCard.njk
+++ b/server/views/partials/keylessSummaryCard.njk
@@ -1,0 +1,22 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% macro keylessSummaryCard(title, actionItems = [], bodyText = undefined, bodyHtml = undefined, testId = '', headingLevel = undefined) %}
+    {{ govukSummaryList({
+        card: {
+            title: {
+                headingLevel: headingLevel,
+                text: title
+            },
+            actions: {
+                items: actionItems
+            },
+            attributes: {
+                "data-testid": testId
+            }
+        },
+        rows: [{
+            key: { text: "", classes: "govuk-visually-hidden" },
+            value: { text: bodyText, html: bodyHtml, classes: "govuk-!-width-full" }
+        }]
+    }) }}
+{% endmacro %}

--- a/server/views/risksAndNeeds/relationships.njk
+++ b/server/views/risksAndNeeds/relationships.njk
@@ -1,0 +1,16 @@
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "../partials/keylessSummaryCard.njk" import keylessSummaryCard %}
+
+<div>
+    {{ govukInsetText(assessmentCompletedText) }}
+    {{ govukSummaryList(domesticViolenceSummaryList) }}
+    {{ keylessSummaryCard(
+        relationshipIssuesDetailsHeading,
+        actionItems,
+        relationshipIssuesDetails,
+        bodyHtml,
+        testId,
+        headingLevel
+    ) }}
+</div>

--- a/server/views/risksAndNeeds/risksAndNeeds.njk
+++ b/server/views/risksAndNeeds/risksAndNeeds.njk
@@ -50,8 +50,9 @@
             educationTrainingAndEmployment
           </div>
             {% elif presenter.subNavValue == 'relationships' %}
-              <div>
-            relationships
+            <div>
+                {% include "./relationships.njk" %}
+            </div>
           </div>
             {% elif presenter.subNavValue == 'lifestyleAndAssociates' %}
               <div>

--- a/wiremock_mappings/oasys.json
+++ b/wiremock_mappings/oasys.json
@@ -109,7 +109,60 @@
         }
       }
     },
-
+    {
+      "request": {
+        "urlPattern": "/assessments/[^/]+/section/section6$",
+        "method": "GET"
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": {
+          "assessmentPk": 10082385,
+          "assessmentType": "LAYER3",
+          "dateCompleted": "2023-12-19T16:57:25",
+          "assessorSignedDate": "2023-12-19T16:55:32",
+          "initiationDate": "2023-12-19T13:41:04",
+          "assessmentStatus": "COMPLETE",
+          "superStatus": "COMPLETE",
+          "laterWIPAssessmentExists": true,
+          "latestWIPDate": "2025-01-29T14:51:36",
+          "laterSignLockAssessmentExists": false,
+          "latestSignLockDate": null,
+          "laterPartCompUnsignedAssessmentExists": true,
+          "latestPartCompUnsignedDate": "2024-04-18T14:08:19",
+          "laterPartCompSignedAssessmentExists": false,
+          "latestPartCompSignedDate": null,
+          "laterCompleteAssessmentExists": true,
+          "latestCompleteDate": "2024-02-21T10:39:07",
+          "relCloseFamily": "0-No problems",
+          "parentalRespProblem": null,
+          "openSexualOffendingQuestions": null,
+          "perpAgainstFamily": null,
+          "victimOfFamily": null,
+          "perpAgainstPartner": null,
+          "victimOfPartner": null,
+          "relLinkedToReoffending": "No",
+          "relLinkedToHarm": "No",
+          "relIssuesDetails": "OPD Automatic screen in as first test",
+          "relParentalResponsibilities": "No",
+          "relCurrRelationshipStatus": "Not in a relationship",
+          "prevOrCurrentDomesticAbuse": "No",
+          "prevCloseRelationships": "2-Significant problems",
+          "relationshipWithPartner": "0-No problems",
+          "experienceOfChildhood": "0-No problems",
+          "emotionalCongruence": "0-No problems",
+          "SARA": {
+            "imminentRiskOfViolenceTowardsPartner": null,
+            "imminentRiskOfViolenceTowardsOthers": null
+          },
+          "assessor": {
+            "name": "LevelTwo CentralSupport"
+          },
+          "crn": "X739590",
+          "nomsId": "A8610DY"
+        }
+      }
+    },
     {
       "request": {
         "urlPattern": "/assessments/.*/section/section13",


### PR DESCRIPTION
This pull request includes the following changes:

- Adds a new relationships page under the risks and needs section.
- Implements the functionality to display and manage oasys derived relationship data.
- Additional controller tests added
- Introduced nunjucks summary card component that doesn't require key values
- Code aligned with the existing project structure and standards.

### Checklist
- [ ] Tested the changes locally
- [ ] Updated documentation if applicable
- [ ] Reviewed all code for potential bugs or refactoring opportunities