### PR TITLE
fix drug misuse tab highlighting the health tab on the risks page

### DIFF
--- a/server/risksAndNeeds/risksAndNeedsController.ts
+++ b/server/risksAndNeeds/risksAndNeedsController.ts
@@ -210,7 +210,7 @@ export default class RisksAndNeedsController {
   async showDrugDetailsPage(req: Request, res: Response): Promise<void> {
     const { referralId } = req.params
     const { username } = req.user
-    const subNavValue = 'health'
+    const subNavValue = 'drugMisuse'
 
     const sharedReferralDetailsData = await this.getSharedPageData(referralId, username)
     const drugDetails = await this.accreditedProgrammesManageAndDeliverService.getDrugDetails(


### PR DESCRIPTION
When selecting the drug misuse tab, the sub-nav component showed that the 'health' section was selected. This small change fixes that.