### PR TITLE
Downgrade faker as there are currently issues with jest integration in v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "timezone-support": "^3.1.0"
       },
       "devDependencies": {
-        "@faker-js/faker": "^10.0.0",
+        "@faker-js/faker": "^9.9.0",
         "@jgoz/esbuild-plugin-typecheck": "^4.0.3",
         "@ministryofjustice/eslint-config-hmpps": "^0.0.4",
         "@tsconfig/node22": "^22.0.2",
@@ -2313,9 +2313,9 @@
       }
     },
     "node_modules/@faker-js/faker": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.0.0.tgz",
-      "integrity": "sha512-UollFEUkVXutsaP+Vndjxar40Gs5JL2HeLcl8xO1QAjJgOdhc3OmBFWyEylS+RddWaaBiAzH+5/17PLQJwDiLw==",
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.9.0.tgz",
+      "integrity": "sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==",
       "dev": true,
       "funding": [
         {
@@ -2325,8 +2325,8 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
-        "npm": ">=10"
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@fastify/busboy": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "timezone-support": "^3.1.0"
   },
   "devDependencies": {
-    "@faker-js/faker": "^10.0.0",
+    "@faker-js/faker": "^9.9.0",
     "@jgoz/esbuild-plugin-typecheck": "^4.0.3",
     "@ministryofjustice/eslint-config-hmpps": "^0.0.4",
     "@tsconfig/node22": "^22.0.2",


### PR DESCRIPTION
There is a currently open issue with faker and jest which is causing issues when running our tests.

Issue here https://github.com/faker-js/faker/issues/3606

Downgrading as this is currently blocking our deployments to dev and v9 is still stable and vulnerability free.