### PR TITLE
APG-1182: Update LDC status for a person

### DIFF
--- a/server/@types/manageAndDeliverApi/index.d.ts
+++ b/server/@types/manageAndDeliverApi/index.d.ts
@@ -29,6 +29,7 @@ type DeliveryLocationPreferences = components['schemas']['DeliveryLocationPrefer
 type PreferredDeliveryLocation = components['schemas']['PreferredDeliveryLocation']
 type ExistingDeliveryLocationPreferences = components['schemas']['ExistingDeliveryLocationPreferences']
 type UpdateCohort = components['schemas']['UpdateCohort']
+type UpdateLdc = components['schemas']['UpdateLdc']
 
 export type {
   AlcoholMisuseDetails,
@@ -36,18 +37,21 @@ export type {
   Availability,
   CohortEnum,
   CreateAvailability,
+  CreateDeliveryLocationPreferences,
   DailyAvailabilityModel,
   DeliveryLocationPreferences,
+  DeliveryLocationPreferencesFormData,
   DrugDetails,
   EmotionalWellbeing,
+  ExistingDeliveryLocationPreferences,
   Health,
   LearningNeeds,
   LifestyleAndAssociates,
-  DeliveryLocationPreferencesFormData,
   OffenceAnalysis,
   OffenceHistory,
   PersonalDetails,
   PniScore,
+  PreferredDeliveryLocation,
   ReferralCaseListItem,
   ReferralDetails,
   Relationships,
@@ -56,8 +60,6 @@ export type {
   SentenceInformation,
   ThinkingAndBehaviour,
   UpdateAvailability,
-  CreateDeliveryLocationPreferences,
-  PreferredDeliveryLocation,
-  ExistingDeliveryLocationPreferences,
   UpdateCohort,
+  UpdateLdc,
 }

--- a/server/cohort/changeCohortController.test.ts
+++ b/server/cohort/changeCohortController.test.ts
@@ -1,12 +1,12 @@
 import { randomUUID } from 'crypto'
 import request from 'supertest'
 
-import { Express } from 'express'
 import { CohortEnum, PersonalDetails, ReferralDetails } from '@manage-and-deliver-api'
-import referralDetailsFactory from '../testutils/factories/referralDetailsFactory'
+import { Express } from 'express'
 import { appWithAllRoutes } from '../routes/testutils/appSetup'
 import AccreditedProgrammesManageAndDeliverService from '../services/accreditedProgrammesManageAndDeliverService'
 import personalDetailsFactory from '../testutils/factories/personalDetailsFactory'
+import referralDetailsFactory from '../testutils/factories/referralDetailsFactory'
 
 jest.mock('../services/accreditedProgrammesManageAndDeliverService')
 jest.mock('../data/hmppsAuthClient')

--- a/server/cohort/changeCohortController.ts
+++ b/server/cohort/changeCohortController.ts
@@ -1,9 +1,9 @@
 import { Request, Response } from 'express'
 import AccreditedProgrammesManageAndDeliverService from '../services/accreditedProgrammesManageAndDeliverService'
 import ControllerUtils from '../utils/controllerUtils'
+import ChangeCohortForm from './changeCohortForm'
 import ChangeCohortPresenter from './changeCohortPresenter'
 import ChangeCohortView from './changeCohortView'
-import ChangeCohortForm from './changeCohortForm'
 
 export default class ChangeCohortController {
   constructor(

--- a/server/ldc/ldcController.test.ts
+++ b/server/ldc/ldcController.test.ts
@@ -51,8 +51,6 @@ describe('Update ldc status', () => {
     it('posts to the update ldc page and redirects successfully', async () => {
       const referralId = randomUUID()
 
-      accreditedProgrammesManageAndDeliverService.getReferralDetails.mockResolvedValue(referralDetails)
-
       return request(app)
         .post(`/referral/${referralId}/update-ldc`)
         .type('form')

--- a/server/ldc/ldcController.test.ts
+++ b/server/ldc/ldcController.test.ts
@@ -1,0 +1,68 @@
+import { randomUUID } from 'crypto'
+import request from 'supertest'
+
+import { ReferralDetails } from '@manage-and-deliver-api'
+import { Express } from 'express'
+import { appWithAllRoutes } from '../routes/testutils/appSetup'
+import AccreditedProgrammesManageAndDeliverService from '../services/accreditedProgrammesManageAndDeliverService'
+import referralDetailsFactory from '../testutils/factories/referralDetailsFactory'
+
+jest.mock('../services/accreditedProgrammesManageAndDeliverService')
+jest.mock('../data/hmppsAuthClient')
+const hmppsAuthClientBuilder = jest.fn()
+
+const accreditedProgrammesManageAndDeliverService = new AccreditedProgrammesManageAndDeliverService(
+  hmppsAuthClientBuilder,
+) as jest.Mocked<AccreditedProgrammesManageAndDeliverService>
+
+let app: Express
+
+const referralDetails: ReferralDetails = referralDetailsFactory.build()
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+beforeEach(() => {
+  app = appWithAllRoutes({
+    services: {
+      accreditedProgrammesManageAndDeliverService,
+    },
+  })
+  accreditedProgrammesManageAndDeliverService.getReferralDetails.mockResolvedValue(referralDetails)
+})
+
+describe('Update ldc status', () => {
+  describe(`GET /referral/:referralId/update-ldc`, () => {
+    it('calls the API with the correct params', async () => {
+      const referralId = randomUUID()
+
+      return request(app)
+        .get(`/referral/${referralId}/update-ldc`)
+        .expect(200)
+        .expect(res => {
+          expect(res.text).toContain(referralDetails.crn)
+          expect(res.text).toContain(referralDetails.personName)
+          expect(res.text).toContain(referralDetails.hasLdcDisplayText)
+        })
+    })
+  })
+
+  describe(`POST /referral/:referralId/update-ldc`, () => {
+    it('posts to the update ldc page and redirects successfully', async () => {
+      const referralId = randomUUID()
+
+      accreditedProgrammesManageAndDeliverService.getReferralDetails.mockResolvedValue(referralDetails)
+
+      return request(app)
+        .post(`/referral/${referralId}/update-ldc`)
+        .type('form')
+        .send({
+          hasLdc: true,
+        })
+        .expect(302)
+        .expect(res => {
+          expect(res.text).toContain('?isLdcUpdated=true')
+        })
+    })
+  })
+})

--- a/server/ldc/ldcController.ts
+++ b/server/ldc/ldcController.ts
@@ -13,7 +13,6 @@ export default class LdcController {
   async showChangeLdcPage(req: Request, res: Response): Promise<void> {
     const { referralId } = req.params
     const { username } = req.user
-
     const referralDetails: ReferralDetails = await this.accreditedProgrammesManageAndDeliverService.getReferralDetails(
       referralId,
       username,

--- a/server/ldc/ldcController.ts
+++ b/server/ldc/ldcController.ts
@@ -1,0 +1,32 @@
+import { ReferralDetails } from '@manage-and-deliver-api'
+import { Request, Response } from 'express'
+import AccreditedProgrammesManageAndDeliverService from '../services/accreditedProgrammesManageAndDeliverService'
+import ControllerUtils from '../utils/controllerUtils'
+import UpdateLdcPresenter from './updateLdcPresenter'
+import UpdateLdcView from './updateLdcView'
+
+export default class LdcController {
+  constructor(
+    private readonly accreditedProgrammesManageAndDeliverService: AccreditedProgrammesManageAndDeliverService,
+  ) {}
+
+  async showChangeLdcPage(req: Request, res: Response): Promise<void> {
+    const { referralId } = req.params
+    const { username } = req.user
+
+    const referralDetails: ReferralDetails = await this.accreditedProgrammesManageAndDeliverService.getReferralDetails(
+      referralId,
+      username,
+    )
+
+    if (req.method === 'POST') {
+      await this.accreditedProgrammesManageAndDeliverService.updateLdc(username, referralId, req.body.hasLdc)
+      return res.redirect(`${req.session.originPage}?isLdcUpdated=true`)
+    }
+
+    const presenter = new UpdateLdcPresenter(referralId, referralDetails, req.session.originPage)
+    const view = new UpdateLdcView(presenter)
+
+    return ControllerUtils.renderWithLayout(res, view, referralDetails)
+  }
+}

--- a/server/ldc/updateLdcPresenter.ts
+++ b/server/ldc/updateLdcPresenter.ts
@@ -7,10 +7,6 @@ export default class UpdateLdcPresenter {
     readonly backlinkUri: string | null,
   ) {}
 
-  get updateLdcFormAction(): string {
-    return `/referral/${this.id}/update-ldc`
-  }
-
   get fields() {
     return {
       hasLdc: {

--- a/server/ldc/updateLdcPresenter.ts
+++ b/server/ldc/updateLdcPresenter.ts
@@ -1,0 +1,21 @@
+import { ReferralDetails } from '@manage-and-deliver-api'
+
+export default class UpdateLdcPresenter {
+  constructor(
+    readonly id: string,
+    readonly details: ReferralDetails,
+    readonly backlinkUri: string | null,
+  ) {}
+
+  get updateLdcFormAction(): string {
+    return `/referral/${this.id}/update-ldc`
+  }
+
+  get fields() {
+    return {
+      hasLdc: {
+        value: this.details.hasLdc,
+      },
+    }
+  }
+}

--- a/server/ldc/updateLdcView.ts
+++ b/server/ldc/updateLdcView.ts
@@ -1,4 +1,4 @@
-import { InsetTextArgs } from '../utils/govukFrontendTypes'
+import { InsetTextArgs, RadiosArgs } from '../utils/govukFrontendTypes'
 import UpdateLdcPresenter from './updateLdcPresenter'
 
 export default class UpdateLdcView {
@@ -10,7 +10,7 @@ export default class UpdateLdcView {
       {
         presenter: this.presenter,
         currentLdcStatusText: this.currentLdcStatusText,
-        radioArgs: this.radioArgs.bind(this),
+        radioArgs: this.radioArgs(),
         backLinkArgs: this.backLinkArgs(),
         backlinkUri: this.presenter.backlinkUri,
       },
@@ -33,7 +33,7 @@ export default class UpdateLdcView {
     }
   }
 
-  private radioArgs() {
+  private radioArgs(): RadiosArgs {
     return {
       name: 'hasLdc',
       fieldset: {
@@ -47,13 +47,14 @@ export default class UpdateLdcView {
         {
           value: 'true',
           text: 'May need an LDC-adapted programme(Building Choices Plus)',
+          checked: this.presenter.fields.hasLdc.value === true,
         },
         {
           value: 'false',
           text: 'Does not need an LDC-adapted programme',
+          checked: this.presenter.fields.hasLdc.value === false,
         },
       ],
-      value: this.presenter.fields.hasLdc.value.toString(),
     }
   }
 }

--- a/server/ldc/updateLdcView.ts
+++ b/server/ldc/updateLdcView.ts
@@ -1,0 +1,59 @@
+import { InsetTextArgs } from '../utils/govukFrontendTypes'
+import UpdateLdcPresenter from './updateLdcPresenter'
+
+export default class UpdateLdcView {
+  constructor(private readonly presenter: UpdateLdcPresenter) {}
+
+  get renderArgs(): [string, Record<string, unknown>] {
+    return [
+      'referralDetails/ldc/updateLdc',
+      {
+        presenter: this.presenter,
+        currentLdcStatusText: this.currentLdcStatusText,
+        radioArgs: this.radioArgs.bind(this),
+        backLinkArgs: this.backLinkArgs(),
+        backlinkUri: this.presenter.backlinkUri,
+      },
+    ]
+  }
+
+  get currentLdcStatusText(): InsetTextArgs {
+    return {
+      html: `<p> ${this.presenter.details.personName}'s current LDC status:</p>
+        <p class="govuk-!-font-weight-bold">${this.presenter.details.hasLdcDisplayText}</p>`,
+
+      classes: 'govuk-!-margin-top-0',
+    }
+  }
+
+  private backLinkArgs() {
+    return {
+      text: 'Back',
+      href: this.presenter.backlinkUri,
+    }
+  }
+
+  private radioArgs() {
+    return {
+      name: 'hasLdc',
+      fieldset: {
+        legend: {
+          text: 'Select the new LDC status',
+          isPageHeading: false,
+          classes: 'govuk-fieldset__legend--m',
+        },
+      },
+      items: [
+        {
+          value: 'true',
+          text: 'May need an LDC-adapted programme(Building Choices Plus)',
+        },
+        {
+          value: 'false',
+          text: 'Does not need an LDC-adapted programme',
+        },
+      ],
+      value: this.presenter.fields.hasLdc.value.toString(),
+    }
+  }
+}

--- a/server/pni/pniController.ts
+++ b/server/pni/pniController.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express'
 import AccreditedProgrammesManageAndDeliverService from '../services/accreditedProgrammesManageAndDeliverService'
-import PniPresenter from './pniPresenter'
 import ControllerUtils from '../utils/controllerUtils'
+import PniPresenter from './pniPresenter'
 import PniView from './pniView'
 
 export default class PniController {
@@ -18,6 +18,8 @@ export default class PniController {
       username,
     )
     const pniScore = await this.accreditedProgrammesManageAndDeliverService.getPniScore(username, referralDetails.crn)
+
+    req.session.originPage = req.originalUrl
 
     const presenter = new PniPresenter(referralId, referralDetails, pniScore)
     const view = new PniView(presenter)

--- a/server/referralDetails/availabilityPresenter.test.ts
+++ b/server/referralDetails/availabilityPresenter.test.ts
@@ -13,6 +13,8 @@ describe(`getAvailabilityTableArgs.`, () => {
       probationPractitionerName: 'Dave Davies',
       probationPractitionerEmail: 'dave.davies@moj.com',
       cohort: 'GENERAL_OFFENCE',
+      hasLdc: true,
+      hasLdcDisplayText: 'May need an LDC-adapted programme',
     }
     const availability: Availability = {
       id: '533f391d-a4dd-4a3f-b53d-e8ff2ab5db86',

--- a/server/referralDetails/personalDetailsPresenter.ts
+++ b/server/referralDetails/personalDetailsPresenter.ts
@@ -11,6 +11,7 @@ export default class PersonalDetailsPresenter extends ReferralDetailsPresenter {
     readonly id: string,
     private personalDetails: PersonalDetails,
     readonly isCohortUpdated: boolean | null = null,
+    readonly isLdcUpdated: boolean | null = null,
   ) {
     super(referralDetails, subNavValue, id, isCohortUpdated)
   }

--- a/server/referralDetails/personalDetailsView.ts
+++ b/server/referralDetails/personalDetailsView.ts
@@ -19,6 +19,7 @@ export default class PersonalDetailsView {
         summary: this.summary,
         importFromDeliusText: this.presenter.importFromDeliusText,
         isCohortUpdated: this.presenter.isCohortUpdated,
+        isLdcUpdated: this.presenter.isLdcUpdated,
       },
     ]
   }

--- a/server/referralDetails/referralDetailsController.ts
+++ b/server/referralDetails/referralDetailsController.ts
@@ -33,7 +33,7 @@ export default class ReferralDetailsController {
 
   async showPersonalDetailsPage(req: Request, res: Response): Promise<void> {
     const { id } = req.params
-    const { isCohortUpdated } = req.query
+    const { isCohortUpdated, isLdcUpdated } = req.query
     const { username } = req.user
     const subNavValue = 'personalDetails'
 
@@ -46,6 +46,7 @@ export default class ReferralDetailsController {
       id,
       personalDetails,
       isCohortUpdated === 'true',
+      isLdcUpdated === 'true',
     )
     const view = new PersonalDetailsView(presenter)
 

--- a/server/referralDetails/referralDetailsPresenter.ts
+++ b/server/referralDetails/referralDetailsPresenter.ts
@@ -1,9 +1,9 @@
 import { ReferralDetails } from '@manage-and-deliver-api'
+import ReferralLayoutPresenter, { HorizontalNavValues } from '../shared/referral/referralLayoutPresenter'
 import { SummaryListArgs } from '../utils/govukFrontendTypes'
 import { SummaryListItem } from '../utils/summaryList'
+import { firstToLowerCase, formatCohort } from '../utils/utils'
 import ViewUtils from '../utils/viewUtils'
-import ReferralLayoutPresenter, { HorizontalNavValues } from '../shared/referral/referralLayoutPresenter'
-import { formatCohort } from '../utils/utils'
 
 export enum ReferralDetailsPageSection {
   PersonalDetailsTab = 'personalDetails',
@@ -28,6 +28,16 @@ export default class ReferralDetailsPresenter extends ReferralLayoutPresenter {
   get referralSummary(): SummaryListArgs {
     return {
       ...ViewUtils.summaryListArgs(this.referralSummaryList(), { showBorders: false }, 'govuk-!-margin-bottom-0'),
+    }
+  }
+
+  get ldcUpdatedSuccessMessageArgs() {
+    return {
+      variant: 'success',
+      title: 'LDC status changed',
+      showTitleAsHeading: true,
+      dismissible: true,
+      text: `${this.referralDetails.personName} ${firstToLowerCase(this.referralDetails.hasLdcDisplayText)}`,
     }
   }
 

--- a/server/risksAndNeeds/risksAndAlerts/risksAndAlertsPresenter.ts
+++ b/server/risksAndNeeds/risksAndAlerts/risksAndAlertsPresenter.ts
@@ -1,6 +1,6 @@
 import { Risks } from '@manage-and-deliver-api'
-import RisksAndNeedsPresenter from '../risksAndNeedsPresenter'
 import { GovukFrontendTableCell } from '../../@types/govukFrontend'
+import RisksAndNeedsPresenter from '../risksAndNeedsPresenter'
 
 export type RiskBox = {
   category: 'OGRS Year 1' | 'OGRS Year 2' | 'OVP Year 1' | 'OVP Year 2' | 'RoSH' | 'RSR' | 'SARA'

--- a/server/risksAndNeeds/risksAndNeedsController.ts
+++ b/server/risksAndNeeds/risksAndNeedsController.ts
@@ -7,6 +7,7 @@ import AlcoholMisusePresenter from './alcoholMisuse/alcoholMisusePresenter'
 import AlcoholMisuseView from './alcoholMisuse/alcoholMisuseView'
 import AttitudesPresenter from './attitudes/attitudesPresenter'
 import AttitudesView from './attitudes/attitudesView'
+import DrugDetailsPresenter from './drugMisuse/drugDetailsPresenter'
 import DrugDetailsView from './drugMisuse/drugDetailsView'
 import EmotionalWellbeingPresenter from './emotionalWellbeing/emotionalWellbeingPresenter'
 import EmotionalWellbeingView from './emotionalWellbeing/emotionalWellbeingView'
@@ -18,15 +19,14 @@ import LifestyleAndAssociatesPresenter from './lifestyleAndAssociates/lifestyleA
 import LifestyleAndAssociatesView from './lifestyleAndAssociates/lifestyleAndAssociatesView'
 import OffenceAnalysisPresenter from './offenceAnalysis/offenceAnalysisPresenter'
 import OffenceAnalysisView from './offenceAnalysis/offenceAnalysisView'
+import RelationshipsPresenter from './relationships/relationshipsPresenter'
+import RelationshipsView from './relationships/relationshipsView'
 import RisksAndAlertsPresenter from './risksAndAlerts/risksAndAlertsPresenter'
 import RisksAndAlertsView from './risksAndAlerts/risksAndAlertsView'
 import RoshAnalysisPresenter from './roshAnalysis/roshAnalysisPresenter'
 import RoshAnalysisView from './roshAnalysis/roshAnalysisView'
 import ThinkingAndBehavingPresenter from './thinkingAndBehaving/thinkingAndBehavingPresenter'
 import ThinkingAndBehavingView from './thinkingAndBehaving/thinkingAndBehavingView'
-import RelationshipsPresenter from './relationships/relationshipsPresenter'
-import RelationshipsView from './relationships/relationshipsView'
-import DrugDetailsPresenter from './drugMisuse/drugDetailsPresenter'
 
 export default class RisksAndNeedsController {
   constructor(
@@ -49,6 +49,8 @@ export default class RisksAndNeedsController {
     )
     const presenter = new RisksAndAlertsPresenter(subNavValue, referralId, risks)
     const view = new RisksAndAlertsView(presenter)
+
+    req.session.originPage = req.originalUrl
 
     return ControllerUtils.renderWithLayout(res, view, sharedReferralDetailsData)
   }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -1,13 +1,14 @@
 import { type RequestHandler, Router } from 'express'
 
-import asyncMiddleware from '../middleware/asyncMiddleware'
-import type { Services } from '../services'
-import ReferralDetailsController from '../referralDetails/referralDetailsController'
 import CaselistController from '../caselist/caselistController'
-import PniController from '../pni/pniController'
-import RisksAndNeedsController from '../risksAndNeeds/risksAndNeedsController'
-import LocationPreferencesController from '../locationPreferences/locationPreferencesController'
 import ChangeCohortController from '../cohort/changeCohortController'
+import LdcController from '../ldc/ldcController'
+import LocationPreferencesController from '../locationPreferences/locationPreferencesController'
+import asyncMiddleware from '../middleware/asyncMiddleware'
+import PniController from '../pni/pniController'
+import ReferralDetailsController from '../referralDetails/referralDetailsController'
+import RisksAndNeedsController from '../risksAndNeeds/risksAndNeedsController'
+import type { Services } from '../services'
 
 export default function routes({ accreditedProgrammesManageAndDeliverService }: Services): Router {
   const router = Router()
@@ -20,6 +21,7 @@ export default function routes({ accreditedProgrammesManageAndDeliverService }: 
   const programmeNeedsIdenfitierController = new PniController(accreditedProgrammesManageAndDeliverService)
   const locationPreferencesController = new LocationPreferencesController(accreditedProgrammesManageAndDeliverService)
   const cohortController = new ChangeCohortController(accreditedProgrammesManageAndDeliverService)
+  const ldcController = new LdcController(accreditedProgrammesManageAndDeliverService)
 
   get('/', async (req, res, next) => {
     await caselistController.showOpenCaselist(req, res)
@@ -163,6 +165,14 @@ export default function routes({ accreditedProgrammesManageAndDeliverService }: 
 
   post('/referral/:referralId/change-cohort', async (req, res, next) => {
     await cohortController.showChangeCohortPage(req, res)
+  })
+
+  get('/referral/:referralId/update-ldc', async (req, res, next) => {
+    await ldcController.showChangeLdcPage(req, res)
+  })
+
+  post('/referral/:referralId/update-ldc', async (req, res, next) => {
+    await ldcController.showChangeLdcPage(req, res)
   })
 
   return router

--- a/server/services/accreditedProgrammesManageAndDeliverService.ts
+++ b/server/services/accreditedProgrammesManageAndDeliverService.ts
@@ -2,8 +2,8 @@ import {
   AlcoholMisuseDetails,
   Attitude,
   Availability,
-  CreateAvailability,
   CohortEnum,
+  CreateAvailability,
   DeliveryLocationPreferences,
   DrugDetails,
   EmotionalWellbeing,
@@ -314,5 +314,14 @@ export default class AccreditedProgrammesManageAndDeliverService
       headers: { Accept: 'application/json' },
       data: { cohort: updateCohort as CohortEnum },
     })) as ReferralDetails
+  }
+
+  async updateLdc(username: string, referralId: string, hasLdc: boolean) {
+    const restClient = await this.createRestClientFromUsername(username)
+    return restClient.post({
+      path: `/referral/${referralId}/update-ldc`,
+      headers: { Accept: 'application/json' },
+      data: { hasLdc },
+    })
   }
 }

--- a/server/shared/referral/referralLayoutPresenter.ts
+++ b/server/shared/referral/referralLayoutPresenter.ts
@@ -11,9 +11,43 @@ export default class ReferralLayoutPresenter {
     readonly referralId: string,
   ) {}
 
+  getButtonMenu(): {
+    button: { text: string; classes: string }
+    items: { text: string; href?: string }[]
+  } {
+    return {
+      button: {
+        text: 'Update referral',
+        classes: 'govuk-button--secondary',
+      },
+      items: [
+        {
+          text: 'Update status',
+          href: '#',
+        },
+        {
+          text: 'Change LDC status',
+          href: '#',
+        },
+        {
+          text: 'Change cohort',
+          href: `/referral/${this.referralId}/change-cohort`,
+        },
+      ],
+    }
+  }
+
   getSubHeaderArgs(): {
     heading: { text: string; classes: string }
-    items: { text: string; classes: string; href?: string }[]
+    items: {
+      text?: string
+      classes?: string
+      href?: string
+      html?: {
+        button: { text: string; classes: string }
+        items: { text: string; href?: string }[]
+      }
+    }[]
   } {
     return {
       heading: {
@@ -26,11 +60,8 @@ export default class ReferralLayoutPresenter {
           classes: 'govuk-button--secondary',
           href: '/pdu/open-referrals',
         },
-
         {
-          text: 'Update cohort',
-          classes: 'govuk-button--secondary',
-          href: `/referral/${this.referralId}/change-cohort`,
+          html: this.getButtonMenu(),
         },
       ],
     }

--- a/server/shared/referral/referralLayoutPresenter.ts
+++ b/server/shared/referral/referralLayoutPresenter.ts
@@ -9,7 +9,15 @@ export default class ReferralLayoutPresenter {
   protected constructor(
     readonly horizontalNavValue: HorizontalNavValues,
     readonly referralId: string,
+    readonly isLdcUpdated: boolean | null = null,
   ) {}
+
+  getButton(): { text: string; classes: string } {
+    return {
+      text: 'Back to referrals',
+      classes: 'govuk-button--secondary',
+    }
+  }
 
   getButtonMenu(): {
     button: { text: string; classes: string }
@@ -27,7 +35,7 @@ export default class ReferralLayoutPresenter {
         },
         {
           text: 'Change LDC status',
-          href: '#',
+          href: `/referral/${this.referralId}/update-ldc`,
         },
         {
           text: 'Change cohort',
@@ -59,9 +67,6 @@ export default class ReferralLayoutPresenter {
           text: 'Back to referrals',
           classes: 'govuk-button--secondary',
           href: '/pdu/open-referrals',
-        },
-        {
-          html: this.getButtonMenu(),
         },
       ],
     }

--- a/server/testutils/factories/referralDetailsFactory.ts
+++ b/server/testutils/factories/referralDetailsFactory.ts
@@ -14,4 +14,6 @@ export default ReferralDetailsFactory.define(({ sequence }) => ({
   probationPractitionerName: 'Prob Officer',
   probationPractitionerEmail: 'prob.officer@example.com',
   cohort: 'SEXUAL_OFFENCE' as CohortEnum,
+  hasLdc: false,
+  hasLdcDisplayText: 'Does not need an LDC-adapted programme',
 }))

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -28,3 +28,13 @@ describe('initialise name', () => {
     expect(initialiseName(a)).toEqual(expected)
   })
 })
+
+describe('convert first letter to lower case', () => {
+  it.each([
+    [null, null, null],
+    ['Empty string', '', null],
+    ['One word', 'Yes', 'yes'],
+    ['Two words', 'Robert James', 'robert James'],
+    ['Three words', 'Does not need', 'does not need'],
+  ])
+})

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,6 +1,9 @@
 const properCase = (word: string): string =>
   word.length >= 1 ? word[0].toUpperCase() + word.toLowerCase().slice(1) : word
 
+export const firstToLowerCase = (word: string): string =>
+  word.length >= 1 ? word[0].toLowerCase() + word.toLowerCase().slice(1) : word
+
 const isBlank = (str: string): boolean => !str || /^\s*$/.test(str)
 
 /**

--- a/server/views/partials/headerMenu.njk
+++ b/server/views/partials/headerMenu.njk
@@ -1,31 +1,13 @@
 {%- from "govuk/components/button/macro.njk" import govukButton %}
 {%- from "moj/components/button-menu/macro.njk" import mojButtonMenu -%}
 
-<div class="moj-button-group moj-button-group--inline">
-    {{ govukButton({
-        text: 'Back to referrals',
-        classes: 'govuk-button--secondary'
-  }) }}
+<div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Referral to Building Choices: moderate intensity</h1>
+</div>
 
-    {{ mojButtonMenu({
-        button: {
-        text: "Update referral",
-        classes: "govuk-button--secondary"
-        },
-        alignMenu: "right",
-        items: [
-        {
-            text: "Update status",
-            href: "#"
-        },
-        {
-            text: "Change LDC status",
-            href: "#"
-        },
-        {
-            text: "Change cohort",
-            href: "#"
-        }
-        ]
-    }) }}
+<div class="govuk-grid-column-one-third">
+    <div class="moj-button-group moj-button-group--inline">
+        {{ govukButton(presenter.getButton()) }}
+        {{ mojButtonMenu(presenter.getButtonMenu()) }}
+    </div>
 </div>

--- a/server/views/partials/headerMenu.njk
+++ b/server/views/partials/headerMenu.njk
@@ -1,0 +1,31 @@
+{%- from "govuk/components/button/macro.njk" import govukButton %}
+{%- from "moj/components/button-menu/macro.njk" import mojButtonMenu -%}
+
+<div class="moj-button-group moj-button-group--inline">
+    {{ govukButton({
+        text: 'Back to referrals',
+        classes: 'govuk-button--secondary'
+  }) }}
+
+    {{ mojButtonMenu({
+        button: {
+        text: "Update referral",
+        classes: "govuk-button--secondary"
+        },
+        alignMenu: "right",
+        items: [
+        {
+            text: "Update status",
+            href: "#"
+        },
+        {
+            text: "Change LDC status",
+            href: "#"
+        },
+        {
+            text: "Change cohort",
+            href: "#"
+        }
+        ]
+    }) }}
+</div>

--- a/server/views/pni/pni.njk
+++ b/server/views/pni/pni.njk
@@ -9,45 +9,49 @@
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block main %}
-{% block content %}
-<div class="govuk-width-container" id="main-content">
-  <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        {{ mojPageHeaderActions(presenter.getSubHeaderArgs()) }}
-        {{ mojSubNavigation(presenter.getHorizontalSubNavArgs()) }}
-      </div>
+  {% block content %}
+    <div class="govuk-width-container" id="main-content">
+      <div class="govuk-main-wrapper">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-full">
+            {{ mojPageHeaderActions(presenter.getSubHeaderArgs()) }}
+            {{ mojSubNavigation(presenter.getHorizontalSubNavArgs()) }}
+          </div>
 
-      <div class="govuk-grid-column-three-quarters">
-        <h2 class="govuk-heading-m">Programme needs identifier</h2>
-        <p class="govuk-body govuk-!-margin-bottom-6">This is {{presenter.details.personName}}'s eligibility for Accredited Programmes, based on their risk and need scores.</p>
-      </div>
+          <div class="govuk-grid-column-three-quarters">
+            <h2 class="govuk-heading-m">Programme needs identifier</h2>
+            <p class="govuk-body govuk-!-margin-bottom-6">This is {{presenter.details.personName}}'s eligibility for Accredited Programmes, based on their risk and need scores.</p>
+          </div>
 
-      <div class="govuk-grid-column-three-quarters">
-        <div class="{{pathwayDetails.class}}">
-          <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
-            <span><strong>{{pathwayDetails.headingText}}</strong></span>
-          </h3>
-          <p class="govuk-body govuk-!-margin-bottom-1">{{pathwayDetails.bodyText}}</p>
+          <div class="govuk-grid-column-three-quarters">
+            <div class="{{pathwayDetails.class}}">
+              <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+                <span>
+                  <strong>{{pathwayDetails.headingText}}</strong>
+                </span>
+              </h3>
+              <p class="govuk-body govuk-!-margin-bottom-1">{{pathwayDetails.bodyText}}</p>
+            </div>
+            <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+          </div>
+
+          <div class="govuk-grid-column-three-quarters">
+            <h2 class="govuk-heading-m">How is this calculated?</h2>
+            <p class="govuk-body">Eligibility is based on a combination of:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>
+                <a href={{ riskAndNeedsUrl }} class="govuk-link">risk scores</a>
+              </li>
+              <li>the programme needs identifier (PNI), which uses the following scores</li>
+            </ul>
+            {{ govukSummaryList(sexSummary) }}
+            {{ govukSummaryList(thinkingSummary) }}
+            {{ govukSummaryList(relationshipsSummary) }}
+            {{ govukSummaryList(selfManagementSummary) }}
+          </div>
         </div>
-        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-      </div>
-
-      <div class="govuk-grid-column-three-quarters">
-        <h2 class="govuk-heading-m">How is this calculated?</h2>
-        <p class="govuk-body">Eligibility is based on a combination of:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li><a href={{ riskAndNeedsUrl }} class="govuk-link">risk scores</a></li>
-          <li>the programme needs identifier (PNI), which uses the following scores</li>
-        </ul>
-        {{ govukSummaryList(sexSummary) }}
-        {{ govukSummaryList(thinkingSummary) }}
-        {{ govukSummaryList(relationshipsSummary) }}
-        {{ govukSummaryList(selfManagementSummary) }}
       </div>
     </div>
-  </div>
-</div>
 
-{% endblock %}
+  {% endblock %}
 {% endblock %}

--- a/server/views/pni/pni.njk
+++ b/server/views/pni/pni.njk
@@ -14,44 +14,51 @@
       <div class="govuk-main-wrapper">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full">
-            {{ mojPageHeaderActions(presenter.getSubHeaderArgs()) }}
-            {{ mojSubNavigation(presenter.getHorizontalSubNavArgs()) }}
-          </div>
-
-          <div class="govuk-grid-column-three-quarters">
-            <h2 class="govuk-heading-m">Programme needs identifier</h2>
-            <p class="govuk-body govuk-!-margin-bottom-6">This is {{presenter.details.personName}}'s eligibility for Accredited Programmes, based on their risk and need scores.</p>
-          </div>
-
-          <div class="govuk-grid-column-three-quarters">
-            <div class="{{pathwayDetails.class}}">
-              <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
-                <span>
-                  <strong>{{pathwayDetails.headingText}}</strong>
-                </span>
-              </h3>
-              <p class="govuk-body govuk-!-margin-bottom-1">{{pathwayDetails.bodyText}}</p>
+            {% include "../partials/headerMenu.njk" %}
+            <div class="govuk-grid-column-full">
+              {{ mojSubNavigation(presenter.getHorizontalSubNavArgs()) }}
             </div>
-            <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-          </div>
 
-          <div class="govuk-grid-column-three-quarters">
-            <h2 class="govuk-heading-m">How is this calculated?</h2>
-            <p class="govuk-body">Eligibility is based on a combination of:</p>
-            <ul class="govuk-list govuk-list--bullet">
-              <li>
-                <a href={{ riskAndNeedsUrl }} class="govuk-link">risk scores</a>
-              </li>
-              <li>the programme needs identifier (PNI), which uses the following scores</li>
-            </ul>
-            {{ govukSummaryList(sexSummary) }}
-            {{ govukSummaryList(thinkingSummary) }}
-            {{ govukSummaryList(relationshipsSummary) }}
-            {{ govukSummaryList(selfManagementSummary) }}
+            <div class="govuk-grid-column-three-quarters">
+              {% if isCohortUpdated %}
+                {{ mojAlert(presenter.cohortUpdatedSuccessMessageArgs) }}
+              {% endif %}
+              {% if isLdcUpdated %}
+                {{ mojAlert(presenter.ldcUpdatedSuccessMessageArgs) }}
+              {% endif %}
+              <h2 class="govuk-heading-m">Programme needs identifier</h2>
+              <p class="govuk-body govuk-!-margin-bottom-6">This is {{presenter.details.personName}}'s eligibility for Accredited Programmes, based on their risk and need scores.</p>
+            </div>
+
+            <div class="govuk-grid-column-three-quarters">
+              <div class="{{pathwayDetails.class}}">
+                <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+                  <span>
+                    <strong>{{pathwayDetails.headingText}}</strong>
+                  </span>
+                </h3>
+                <p class="govuk-body govuk-!-margin-bottom-1">{{pathwayDetails.bodyText}}</p>
+              </div>
+              <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+            </div>
+
+            <div class="govuk-grid-column-three-quarters">
+              <h2 class="govuk-heading-m">How is this calculated?</h2>
+              <p class="govuk-body">Eligibility is based on a combination of:</p>
+              <ul class="govuk-list govuk-list--bullet">
+                <li>
+                  <a href={{ riskAndNeedsUrl }} class="govuk-link">risk scores</a>
+                </li>
+                <li>the programme needs identifier (PNI), which uses the following scores</li>
+              </ul>
+              {{ govukSummaryList(sexSummary) }}
+              {{ govukSummaryList(thinkingSummary) }}
+              {{ govukSummaryList(relationshipsSummary) }}
+              {{ govukSummaryList(selfManagementSummary) }}
+            </div>
           </div>
         </div>
       </div>
-    </div>
 
+    {% endblock %}
   {% endblock %}
-{% endblock %}

--- a/server/views/referralDetails/ldc/updateLdc.njk
+++ b/server/views/referralDetails/ldc/updateLdc.njk
@@ -15,10 +15,10 @@
             <div class="govuk-main-wrapper">
                 <h2 class="govuk-heading-l" data-testid="cohort-heading">Update learning disabilities and challenges(LDC)</h2>
                 {{ govukInsetText(currentLdcStatusText) }}
-                <form method="post" novalidate action="{{ presenter.updateLdcFormAction }}">
+                <form method="post" novalidate>
                     <input type="hidden" name="_csrf" value="{{csrfToken}}">
 
-                    {{ govukRadios(radioArgs()) }}
+                    {{ govukRadios(radioArgs) }}
 
                     <div class="govuk-button-group">
                         {{ govukButton({ text: "Submit", preventDoubleClick: true }) }}

--- a/server/views/referralDetails/ldc/updateLdc.njk
+++ b/server/views/referralDetails/ldc/updateLdc.njk
@@ -5,7 +5,6 @@
 {% set mainClasses = "app-container govuk-body" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{%- from "moj/components/alert/macro.njk" import mojAlert -%}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% block main %}
@@ -14,9 +13,9 @@
         <div class="govuk-width-container" id="main-content">
             {{ govukBackLink(backLinkArgs) }}
             <div class="govuk-main-wrapper">
-                <h2 class="govuk-heading-l" data-testid="cohort-heading">Which cohort should {{presenter.details.personName}} be in?</h2>
-                {{ govukInsetText(currentCohortText) }}
-                <form method="post" novalidate action="{{ presenter.changeCohortFormAction }}">
+                <h2 class="govuk-heading-l" data-testid="cohort-heading">Update learning disabilities and challenges(LDC)</h2>
+                {{ govukInsetText(currentLdcStatusText) }}
+                <form method="post" novalidate action="{{ presenter.updateLdcFormAction }}">
                     <input type="hidden" name="_csrf" value="{{csrfToken}}">
 
                     {{ govukRadios(radioArgs()) }}

--- a/server/views/referralDetails/referralDetails.njk
+++ b/server/views/referralDetails/referralDetails.njk
@@ -9,73 +9,71 @@
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block main %}
-{% block content %}
-<div class="govuk-width-container" id="main-content">
-  <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        {{ mojPageHeaderActions(presenter.getSubHeaderArgs()) }}
-        {{ mojSubNavigation(presenter.getHorizontalSubNavArgs()) }}
+  {% block content %}
+    <div class="govuk-width-container" id="main-content">
+      <div class="govuk-main-wrapper">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-full">
+            {# {% include "../partials/headerMenu.njk" %} #}
+            {{ mojPageHeaderActions(presenter.getSubHeaderArgs()) }}
+            {{ mojSubNavigation(presenter.getHorizontalSubNavArgs()) }}
 
-        <div class="govuk-grid-column-three-quarters">
-          {% if isCohortUpdated %}
-            {{ mojAlert(presenter.cohortUpdatedSuccessMessageArgs) }}
-          {% endif %}
-          <h2 class="govuk-heading-m">Referral summary</h2>
-          {{ govukSummaryList(presenter.referralSummary) }}
+            <div class="govuk-grid-column-three-quarters">
+              {% if isCohortUpdated %}
+                {{ mojAlert(presenter.cohortUpdatedSuccessMessageArgs) }}
+              {% endif %}
+              <h2 class="govuk-heading-m">Referral summary</h2>
+              {{ govukSummaryList(presenter.referralSummary) }}
+            </div>
+          </div>
         </div>
-      </div>
-    </div>
 
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-          <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-full">
+            <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+          </div>
         </div>
-      </div>
-      <div class="govuk-grid-row">
+        <div class="govuk-grid-row">
 
-        <div class="govuk-grid-column-one-third">
+          <div class="govuk-grid-column-one-third">
 
-          {{ mojSideNavigation(presenter.getVerticalSubNavArgs()) }}
+            {{ mojSideNavigation(presenter.getVerticalSubNavArgs()) }}
 
-        </div>
-        <div class="govuk-grid-column-two-thirds">
-          {% if presenter.subNavValue == 'programmeHistory' %}
-          <div>
+          </div>
+          <div class="govuk-grid-column-two-thirds">
+            {% if presenter.subNavValue == 'programmeHistory' %}
+              <div>
 
             Programme History
           </div>
-          {% elif presenter.subNavValue == 'offenceHistory' %}
-          <div>
-            {% include "./offenceHistory.njk" %}
-          </div>
-          {% elif presenter.subNavValue == 'sentenceInformation' %}
-          <div>
-            {% include "./sentenceInformation.njk" %}
-          </div>
-          {% elif presenter.subNavValue == 'availability' %}
-          <div>
-            {% include "./availability.njk" %}
-          </div>
-          {% elif presenter.subNavValue == 'location' %}
-          <div>
-            {% include "./location.njk" %}
-          </div>
-          {% elif presenter.subNavValue == 'additionalInformation' %}
-          <div>
+            {% elif presenter.subNavValue == 'offenceHistory' %}
+              <div>
+                {% include "./offenceHistory.njk" %}
+              </div>
+            {% elif presenter.subNavValue == 'sentenceInformation' %}
+              <div>
+                {% include "./sentenceInformation.njk" %}
+              </div>
+            {% elif presenter.subNavValue == 'availability' %}
+              <div>
+                {% include "./availability.njk" %}
+              </div>
+            {% elif presenter.subNavValue == 'location' %}
+              <div>
+                {% include "./location.njk" %}
+              </div>
+            {% elif presenter.subNavValue == 'additionalInformation' %}
+              <div>
             Additional Information
           </div>
-          {% else %}
-            {% include "./personalDetails.njk" %}
-          {% endif %}
+            {% else %}
+              {% include "./personalDetails.njk" %}
+            {% endif %}
+          </div>
         </div>
+
       </div>
+    </div>
 
-  </div>
-</div>
-
+  {% endblock %}
 {% endblock %}
-{% endblock %}
-
-
-

--- a/server/views/referralDetails/referralDetails.njk
+++ b/server/views/referralDetails/referralDetails.njk
@@ -14,73 +14,71 @@
       <div class="govuk-main-wrapper">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full">
-<!--            {# {% include "../partials/headerMenu.njk" %} #}-->
-<!--            {{ mojPageHeaderActions(presenter.getSubHeaderArgs()) }}-->
-<!--            {{ mojSubNavigation(presenter.getHorizontalSubNavArgs()) }}-->
-            <div class="govuk-grid-column-two-thirds">
-              <h1 class="govuk-heading-xl">Referral to Building Choices: moderate intensity</h1>
-            </div>
-
-            <div class="govuk-grid-column-one-third">
-              {% include "../partials/headerMenu.njk" %}
+            {% include "../partials/headerMenu.njk" %}
+            <div class="govuk-grid-column-full">
+              {{ mojSubNavigation(presenter.getHorizontalSubNavArgs()) }}
             </div>
 
             <div class="govuk-grid-column-three-quarters">
               {% if isCohortUpdated %}
                 {{ mojAlert(presenter.cohortUpdatedSuccessMessageArgs) }}
               {% endif %}
+              {% if isLdcUpdated %}
+                {{ mojAlert(presenter.ldcUpdatedSuccessMessageArgs) }}
+              {% endif %}
               <h2 class="govuk-heading-m">Referral summary</h2>
               {{ govukSummaryList(presenter.referralSummary) }}
             </div>
           </div>
         </div>
+      </div>
 
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-full">
-            <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-          </div>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
         </div>
-        <div class="govuk-grid-row">
+      </div>
+      <div class="govuk-grid-row">
 
-          <div class="govuk-grid-column-one-third">
+        <div class="govuk-grid-column-one-third">
 
-            {{ mojSideNavigation(presenter.getVerticalSubNavArgs()) }}
+          {{ mojSideNavigation(presenter.getVerticalSubNavArgs()) }}
 
-          </div>
-          <div class="govuk-grid-column-two-thirds">
-            {% if presenter.subNavValue == 'programmeHistory' %}
-              <div>
+        </div>
+        <div class="govuk-grid-column-two-thirds">
+          {% if presenter.subNavValue == 'programmeHistory' %}
+            <div>
 
             Programme History
           </div>
-            {% elif presenter.subNavValue == 'offenceHistory' %}
-              <div>
-                {% include "./offenceHistory.njk" %}
-              </div>
-            {% elif presenter.subNavValue == 'sentenceInformation' %}
-              <div>
-                {% include "./sentenceInformation.njk" %}
-              </div>
-            {% elif presenter.subNavValue == 'availability' %}
-              <div>
-                {% include "./availability.njk" %}
-              </div>
-            {% elif presenter.subNavValue == 'location' %}
-              <div>
-                {% include "./location.njk" %}
-              </div>
-            {% elif presenter.subNavValue == 'additionalInformation' %}
-              <div>
+          {% elif presenter.subNavValue == 'offenceHistory' %}
+            <div>
+              {% include "./offenceHistory.njk" %}
+            </div>
+          {% elif presenter.subNavValue == 'sentenceInformation' %}
+            <div>
+              {% include "./sentenceInformation.njk" %}
+            </div>
+          {% elif presenter.subNavValue == 'availability' %}
+            <div>
+              {% include "./availability.njk" %}
+            </div>
+          {% elif presenter.subNavValue == 'location' %}
+            <div>
+              {% include "./location.njk" %}
+            </div>
+          {% elif presenter.subNavValue == 'additionalInformation' %}
+            <div>
             Additional Information
           </div>
-            {% else %}
-              {% include "./personalDetails.njk" %}
-            {% endif %}
-          </div>
+          {% else %}
+            {% include "./personalDetails.njk" %}
+          {% endif %}
         </div>
-
       </div>
-    </div>
 
-  {% endblock %}
+    </div>
+  </div>
+
+{% endblock %}
 {% endblock %}

--- a/server/views/referralDetails/referralDetails.njk
+++ b/server/views/referralDetails/referralDetails.njk
@@ -14,9 +14,16 @@
       <div class="govuk-main-wrapper">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full">
-            {# {% include "../partials/headerMenu.njk" %} #}
-            {{ mojPageHeaderActions(presenter.getSubHeaderArgs()) }}
-            {{ mojSubNavigation(presenter.getHorizontalSubNavArgs()) }}
+<!--            {# {% include "../partials/headerMenu.njk" %} #}-->
+<!--            {{ mojPageHeaderActions(presenter.getSubHeaderArgs()) }}-->
+<!--            {{ mojSubNavigation(presenter.getHorizontalSubNavArgs()) }}-->
+            <div class="govuk-grid-column-two-thirds">
+              <h1 class="govuk-heading-xl">Referral to Building Choices: moderate intensity</h1>
+            </div>
+
+            <div class="govuk-grid-column-one-third">
+              {% include "../partials/headerMenu.njk" %}
+            </div>
 
             <div class="govuk-grid-column-three-quarters">
               {% if isCohortUpdated %}

--- a/server/views/risksAndNeeds/risksAndNeeds.njk
+++ b/server/views/risksAndNeeds/risksAndNeeds.njk
@@ -34,38 +34,38 @@
           </div>
           <div class="govuk-grid-column-two-thirds">
             {% if presenter.subNavValue == 'learningNeeds' %}
-            <div>
-                  {% include "./learningNeeds.njk" %}
-            </div>
+              <div>
+                {% include "./learningNeeds.njk" %}
+              </div>
             {% elif presenter.subNavValue == 'offenceAnalysis' %}
-            <div>
-              {% include "./offenceAnalysis.njk" %}
-            </div>
+              <div>
+                {% include "./offenceAnalysis.njk" %}
+              </div>
             {% elif presenter.subNavValue == 'relationships' %}
-            <div>
+              <div>
                 {% include "./relationships.njk" %}
-            </div>
+              </div>
             {% elif presenter.subNavValue == 'lifestyleAndAssociates' %}
               <div>
                 {% include "./lifestyleAndAssociates.njk" %}
               </div>
             {% elif presenter.subNavValue == 'drugMisuse' %}
-            <div>
-              {% include "./drugMisuseDetails.njk" %}
-            </div>
+              <div>
+                {% include "./drugMisuseDetails.njk" %}
+              </div>
             {% elif presenter.subNavValue == 'alcoholMisuse' %}
-            <div>
+              <div>
                 {% include "./alcoholMisuse.njk" %}
-            </div>
+              </div>
             {% elif presenter.subNavValue == 'emotionalWellbeing' %}
-            <div>
-              {% include "./emotionalWellbeing.njk" %}
-            </div>
+              <div>
+                {% include "./emotionalWellbeing.njk" %}
+              </div>
             {% elif presenter.subNavValue == 'thinkingAndBehaviour' %}
-            <div>
-              {% include "./thinkingAndBehaviour.njk" %}
-            </div>
-              {% elif presenter.subNavValue == 'attitudes' %}
+              <div>
+                {% include "./thinkingAndBehaviour.njk" %}
+              </div>
+            {% elif presenter.subNavValue == 'attitudes' %}
               <div>
                 {% include "./attitudes.njk" %}
               </div>
@@ -79,7 +79,7 @@
               </div>
             {% else %}
               <div>
-              {% include "./risksAndAlerts.njk" %}
+                {% include "./risksAndAlerts.njk" %}
               </div>
             {% endif %}
           </div>

--- a/server/views/risksAndNeeds/risksAndNeeds.njk
+++ b/server/views/risksAndNeeds/risksAndNeeds.njk
@@ -14,9 +14,18 @@
       <div class="govuk-main-wrapper">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full">
-            {{ mojPageHeaderActions(presenter.getSubHeaderArgs()) }}
-            {{ mojSubNavigation(presenter.getHorizontalSubNavArgs()) }}
+            {% include "../partials/headerMenu.njk" %}
+            <div class="govuk-grid-column-full">
+              {{ mojSubNavigation(presenter.getHorizontalSubNavArgs()) }}
+            </div>
+
             <div class="govuk-grid-column-three-quarters">
+              {% if isCohortUpdated %}
+                {{ mojAlert(presenter.cohortUpdatedSuccessMessageArgs) }}
+              {% endif %}
+              {% if isLdcUpdated %}
+                {{ mojAlert(presenter.ldcUpdatedSuccessMessageArgs) }}
+              {% endif %}
               <h2 class="govuk-heading-m">Risks and needs</h2>
               <p class="govuk-body govuk-!-margin-bottom-0">{{ presenter.pageDescription }}</p>
             </div>


### PR DESCRIPTION
This PR adds the ability for a user to update the ldc status of a referral. Shown below are the screens that have been implemented.

<img width="864" height="198" alt="image" src="https://github.com/user-attachments/assets/b85d62af-e3c6-4c66-849a-f52a505f555a" />
<img width="988" height="522" alt="image" src="https://github.com/user-attachments/assets/37b96a39-231a-41de-922b-6c724543181d" />

## KNOWN ISSUES
- The success alert box when updating ldc status will only appear when updated on the personal details section page, this is an existing issue in the cohort journey as well and requires changes in many files which would muddy this PR.
- Query params are being duplicated if updating status multiple times in a row, this also exists in the cohort journey and for same reason above will address in another pr,.
