### PR TITLE
Manage LDC and cohort messages from the parent presenter

### DIFF
--- a/server/cohort/changeCohortController.test.ts
+++ b/server/cohort/changeCohortController.test.ts
@@ -1,10 +1,8 @@
-import { randomUUID } from 'crypto'
 import request from 'supertest'
 
 import { CohortEnum, PersonalDetails, ReferralDetails } from '@manage-and-deliver-api'
 import { Express } from 'express'
 import { SessionData } from 'express-session'
-import { appWithAllRoutes } from '../routes/testutils/appSetup'
 import AccreditedProgrammesManageAndDeliverService from '../services/accreditedProgrammesManageAndDeliverService'
 import personalDetailsFactory from '../testutils/factories/personalDetailsFactory'
 import referralDetailsFactory from '../testutils/factories/referralDetailsFactory'

--- a/server/cohort/changeCohortController.ts
+++ b/server/cohort/changeCohortController.ts
@@ -26,7 +26,7 @@ export default class ChangeCohortController {
         referralId,
         data.paramsForUpdate.updatedCohort,
       )
-      return res.redirect(`/referral-details/${referralId}/personal-details?isCohortUpdated=true`)
+      return res.redirect(`${req.session.originPage}?isCohortUpdated=true`)
     }
 
     const presenter = new ChangeCohortPresenter(referralId, referralDetails, req.session.originPage)

--- a/server/pni/pniController.ts
+++ b/server/pni/pniController.ts
@@ -12,6 +12,7 @@ export default class PniController {
   async showProgrammeNeedsIdentifierPage(req: Request, res: Response): Promise<void> {
     const { referralId } = req.params
     const { username } = req.user
+    const { isCohortUpdated, isLdcUpdated } = req.query
 
     const referralDetails = await this.accreditedProgrammesManageAndDeliverService.getReferralDetails(
       referralId,
@@ -19,9 +20,15 @@ export default class PniController {
     )
     const pniScore = await this.accreditedProgrammesManageAndDeliverService.getPniScore(username, referralDetails.crn)
 
-    req.session.originPage = req.originalUrl
+    req.session.originPage = req.path
 
-    const presenter = new PniPresenter(referralId, referralDetails, pniScore)
+    const presenter = new PniPresenter(
+      referralId,
+      referralDetails,
+      pniScore,
+      isLdcUpdated === 'true',
+      isCohortUpdated === 'true',
+    )
     const view = new PniView(presenter)
 
     ControllerUtils.renderWithLayout(res, view, referralDetails)

--- a/server/pni/pniPresenter.ts
+++ b/server/pni/pniPresenter.ts
@@ -4,10 +4,12 @@ import ReferralLayoutPresenter, { HorizontalNavValues } from '../shared/referral
 export default class PniPresenter extends ReferralLayoutPresenter {
   constructor(
     readonly id: string,
-    readonly details: ReferralDetails,
+    readonly referral: ReferralDetails,
     readonly pniScore: PniScore,
+    readonly isLdcUpdated: boolean | null = null,
+    readonly isCohortUpdated: boolean | null = null,
   ) {
-    super(HorizontalNavValues.programmeNeedsIdentifierTab, id, details.currentStatusDescription)
+    super(HorizontalNavValues.programmeNeedsIdentifierTab, referral, isLdcUpdated, isCohortUpdated)
   }
 
   scoreValueText(value?: number | null): string {
@@ -219,7 +221,7 @@ export default class PniPresenter extends ReferralLayoutPresenter {
   }
 
   getPathwayDetails() {
-    const bodyTextPrefix = `Based on the risk and need scores, ${this.details.personName} may`
+    const bodyTextPrefix = `Based on the risk and need scores, ${this.referral.personName} may`
     const programmePathway = this.pniScore.overallIntensity
     switch (programmePathway) {
       case 'HIGH':

--- a/server/referralDetails/additionalInformationPresenter.ts
+++ b/server/referralDetails/additionalInformationPresenter.ts
@@ -5,8 +5,9 @@ export default class AdditionalInformationPresenter extends ReferralDetailsPrese
   constructor(
     readonly details: ReferralDetails,
     readonly subNavValue: string,
-    readonly id: string,
+    readonly isLdcUpdated: boolean | null = null,
+    readonly isCohortUpdated: boolean | null = null,
   ) {
-    super(details, subNavValue, id)
+    super(details, subNavValue, isLdcUpdated, isCohortUpdated)
   }
 }

--- a/server/referralDetails/availabilityPresenter.test.ts
+++ b/server/referralDetails/availabilityPresenter.test.ts
@@ -84,7 +84,7 @@ describe(`getAvailabilityTableArgs.`, () => {
         },
       ],
     }
-    const presenter = new AvailabilityPresenter(referralDetails, 'availability', '12345', availability)
+    const presenter = new AvailabilityPresenter(referralDetails, 'availability', availability)
     expect(presenter.getAvailabilityTableArgs()).toEqual({
       firstCellIsHeader: true,
       head: [{ text: 'Day' }, { text: 'Daytime' }, { text: 'Evening' }, { text: 'Nighttime' }],

--- a/server/referralDetails/availabilityPresenter.ts
+++ b/server/referralDetails/availabilityPresenter.ts
@@ -5,11 +5,12 @@ export default class AvailabilityPresenter extends ReferralDetailsPresenter {
   constructor(
     readonly details: ReferralDetails,
     readonly subNavValue: string,
-    readonly id: string,
     readonly availability: Availability,
     readonly isAvailabilityUpdated: boolean | null = null,
+    readonly isLdcUpdated: boolean | null = null,
+    readonly isCohortUpdated: boolean | null = null,
   ) {
-    super(details, subNavValue, id)
+    super(details, subNavValue, isLdcUpdated, isCohortUpdated)
   }
 
   get showAvailability(): boolean {

--- a/server/referralDetails/availabilityView.ts
+++ b/server/referralDetails/availabilityView.ts
@@ -22,8 +22,8 @@ export default class AvailabilityView {
     return {
       text: this.presenter.availability.id ? 'Change availability' : 'Add availability',
       href: this.presenter.availability.id
-        ? `/referral/${this.presenter.id}/update-availability/${this.presenter.availability.id}`
-        : `/referral/${this.presenter.id}/add-availability`,
+        ? `/referral/${this.presenter.referralDetails.id}/update-availability/${this.presenter.availability.id}`
+        : `/referral/${this.presenter.referralDetails.id}/add-availability`,
     }
   }
 

--- a/server/referralDetails/locationPresenter.ts
+++ b/server/referralDetails/locationPresenter.ts
@@ -6,11 +6,12 @@ export default class LocationPresenter extends ReferralDetailsPresenter {
   constructor(
     readonly details: ReferralDetails,
     readonly subNavValue: string,
-    readonly id: string,
     readonly deliveryLocationPreferences: DeliveryLocationPreferences,
     readonly isPreferredLocationUpdated: boolean | null = null,
+    readonly isLdcUpdated: boolean | null = null,
+    readonly isCohortUpdated: boolean | null = null,
   ) {
-    super(details, subNavValue, id)
+    super(details, subNavValue, isLdcUpdated, isCohortUpdated)
   }
 
   get linkText() {

--- a/server/referralDetails/locationView.ts
+++ b/server/referralDetails/locationView.ts
@@ -7,7 +7,7 @@ export default class LocationView {
 
   get getPreferredLocationsAsSummaryListArgs(): SummaryListArgs {
     const summary = this.presenter.preferredLocationsSummary()
-    const addLocationPreferenceHref = `/referral/${this.presenter.referralId}/add-location-preferences`
+    const addLocationPreferenceHref = `/referral/${this.presenter.referralDetails.id}/add-location-preferences`
     return ViewUtils.summaryListArgsWithSummaryCard(
       summary.summary,
       summary.title,

--- a/server/referralDetails/offenceHistoryPresenter.ts
+++ b/server/referralDetails/offenceHistoryPresenter.ts
@@ -7,10 +7,11 @@ export default class OffenceHistoryPresenter extends ReferralDetailsPresenter {
   constructor(
     readonly details: ReferralDetails,
     readonly subNavValue: string,
-    readonly id: string,
     readonly offenceHistory: OffenceHistory,
+    readonly isLdcUpdated: boolean | null = null,
+    readonly isCohortUpdated: boolean | null = null,
   ) {
-    super(details, subNavValue, id)
+    super(details, subNavValue, isLdcUpdated, isCohortUpdated)
   }
 
   offenceHistorySummaryLists(): { title: string; summary: SummaryListItem[] }[] {

--- a/server/referralDetails/personalDetailsPresenter.ts
+++ b/server/referralDetails/personalDetailsPresenter.ts
@@ -8,12 +8,11 @@ export default class PersonalDetailsPresenter extends ReferralDetailsPresenter {
   constructor(
     readonly referralDetails: ReferralDetails,
     readonly subNavValue: string,
-    readonly id: string,
     private personalDetails: PersonalDetails,
-    readonly isCohortUpdated: boolean | null = null,
     readonly isLdcUpdated: boolean | null = null,
+    readonly isCohortUpdated: boolean | null = null,
   ) {
-    super(referralDetails, subNavValue, id, isCohortUpdated)
+    super(referralDetails, subNavValue, isLdcUpdated, isCohortUpdated)
   }
 
   get importFromDeliusText(): InsetTextArgs {

--- a/server/referralDetails/personalDetailsView.ts
+++ b/server/referralDetails/personalDetailsView.ts
@@ -18,8 +18,6 @@ export default class PersonalDetailsView {
         presenter: this.presenter,
         summary: this.summary,
         importFromDeliusText: this.presenter.importFromDeliusText,
-        isCohortUpdated: this.presenter.isCohortUpdated,
-        isLdcUpdated: this.presenter.isLdcUpdated,
       },
     ]
   }

--- a/server/referralDetails/programmeHistoryPresenter.ts
+++ b/server/referralDetails/programmeHistoryPresenter.ts
@@ -5,8 +5,9 @@ export default class ProgrammeHistoryPresenter extends ReferralDetailsPresenter 
   constructor(
     readonly details: ReferralDetails,
     readonly subNavValue: string,
-    readonly id: string,
+    readonly isLdcUpdated: boolean | null = null,
+    readonly isCohortUpdated: boolean | null = null,
   ) {
-    super(details, subNavValue, id)
+    super(details, subNavValue, isLdcUpdated, isCohortUpdated)
   }
 }

--- a/server/referralDetails/referralDetailsController.ts
+++ b/server/referralDetails/referralDetailsController.ts
@@ -43,10 +43,9 @@ export default class ReferralDetailsController {
     const presenter = new PersonalDetailsPresenter(
       sharedReferralDetailsData,
       subNavValue,
-      id,
       personalDetails,
-      isCohortUpdated === 'true',
       isLdcUpdated === 'true',
+      isCohortUpdated === 'true',
     )
     const view = new PersonalDetailsView(presenter)
 
@@ -58,11 +57,17 @@ export default class ReferralDetailsController {
   async showProgrammeHistoryPage(req: Request, res: Response): Promise<void> {
     const { id } = req.params
     const { username } = req.user
+    const { isCohortUpdated, isLdcUpdated } = req.query
     const subNavValue = 'programmeHistory'
 
     const sharedReferralDetailsData = await this.showReferralDetailsPage(id, username)
 
-    const presenter = new ProgrammeHistoryPresenter(sharedReferralDetailsData, subNavValue, id)
+    const presenter = new ProgrammeHistoryPresenter(
+      sharedReferralDetailsData,
+      subNavValue,
+      isLdcUpdated === 'true',
+      isCohortUpdated === 'true',
+    )
     const view = new ProgrammeHistoryView(presenter)
 
     req.session.originPage = req.path
@@ -73,12 +78,19 @@ export default class ReferralDetailsController {
   async showOffenceHistoryPage(req: Request, res: Response): Promise<void> {
     const { id } = req.params
     const { username } = req.user
+    const { isCohortUpdated, isLdcUpdated } = req.query
     const subNavValue = 'offenceHistory'
 
     const sharedReferralDetailsData = await this.showReferralDetailsPage(id, username)
     const offenceHistory = await this.accreditedProgrammesManageAndDeliverService.getOffenceHistory(username, id)
 
-    const presenter = new OffenceHistoryPresenter(sharedReferralDetailsData, subNavValue, id, offenceHistory)
+    const presenter = new OffenceHistoryPresenter(
+      sharedReferralDetailsData,
+      subNavValue,
+      offenceHistory,
+      isLdcUpdated === 'true',
+      isCohortUpdated === 'true',
+    )
     const view = new OffenceHistoryView(presenter)
 
     req.session.originPage = req.path
@@ -89,6 +101,7 @@ export default class ReferralDetailsController {
   async showSentenceInformationPage(req: Request, res: Response): Promise<void> {
     const { id } = req.params
     const { username } = req.user
+    const { isCohortUpdated, isLdcUpdated } = req.query
     const subNavValue = 'sentenceInformation'
 
     const sharedReferralDetailsData = await this.showReferralDetailsPage(id, username)
@@ -97,7 +110,13 @@ export default class ReferralDetailsController {
       id,
     )
 
-    const presenter = new SentenceInformationPresenter(sharedReferralDetailsData, subNavValue, id, sentenceInformation)
+    const presenter = new SentenceInformationPresenter(
+      sharedReferralDetailsData,
+      subNavValue,
+      sentenceInformation,
+      isLdcUpdated === 'true',
+      isCohortUpdated === 'true',
+    )
     const view = new SentenceInformationView(presenter)
 
     req.session.originPage = req.path
@@ -108,7 +127,7 @@ export default class ReferralDetailsController {
   async showAvailabilityPage(req: Request, res: Response): Promise<void> {
     const { id } = req.params
     const { username } = req.user
-    const { detailsUpdated } = req.query
+    const { isCohortUpdated, isLdcUpdated, detailsUpdated } = req.query
     const subNavValue = 'availability'
 
     const sharedReferralDetailsData = await this.showReferralDetailsPage(id, username)
@@ -118,9 +137,10 @@ export default class ReferralDetailsController {
     const presenter = new AvailabilityPresenter(
       sharedReferralDetailsData,
       subNavValue,
-      id,
       availability,
       detailsUpdated === 'true',
+      isLdcUpdated === 'true',
+      isCohortUpdated === 'true',
     )
     const view = new AvailabilityView(presenter)
 
@@ -132,7 +152,7 @@ export default class ReferralDetailsController {
   async showLocationPage(req: Request, res: Response): Promise<void> {
     const { id } = req.params
     const { username } = req.user
-    const { preferredLocationUpdated } = req.query
+    const { isCohortUpdated, isLdcUpdated, preferredLocationUpdated } = req.query
     const subNavValue = 'location'
 
     const sharedReferralDetailsData = await this.showReferralDetailsPage(id, username)
@@ -143,9 +163,10 @@ export default class ReferralDetailsController {
     const presenter = new LocationPresenter(
       sharedReferralDetailsData,
       subNavValue,
-      id,
       deliveryLocationPreferences,
       preferredLocationUpdated === 'true',
+      isLdcUpdated === 'true',
+      isCohortUpdated === 'true',
     )
     const view = new LocationView(presenter)
 
@@ -157,12 +178,20 @@ export default class ReferralDetailsController {
   async showAdditionalInformationPage(req: Request, res: Response): Promise<void> {
     const { id } = req.params
     const { username } = req.user
+    const { isCohortUpdated, isLdcUpdated } = req.query
     const subNavValue = 'additionalInformation'
 
     const sharedReferralDetailsData = await this.showReferralDetailsPage(id, username)
 
-    const presenter = new AdditionalInformationPresenter(sharedReferralDetailsData, subNavValue, id)
+    const presenter = new AdditionalInformationPresenter(
+      sharedReferralDetailsData,
+      subNavValue,
+      isLdcUpdated === 'true',
+      isCohortUpdated === 'true',
+    )
     const view = new AdditionalInformationView(presenter)
+
+    req.session.originPage = req.path
 
     ControllerUtils.renderWithLayout(res, view, sharedReferralDetailsData)
   }

--- a/server/referralDetails/referralDetailsPresenter.ts
+++ b/server/referralDetails/referralDetailsPresenter.ts
@@ -2,7 +2,7 @@ import { ReferralDetails } from '@manage-and-deliver-api'
 import ReferralLayoutPresenter, { HorizontalNavValues } from '../shared/referral/referralLayoutPresenter'
 import { SummaryListArgs } from '../utils/govukFrontendTypes'
 import { SummaryListItem } from '../utils/summaryList'
-import { firstToLowerCase, formatCohort } from '../utils/utils'
+import { formatCohort } from '../utils/utils'
 import ViewUtils from '../utils/viewUtils'
 
 export enum ReferralDetailsPageSection {
@@ -19,35 +19,15 @@ export default class ReferralDetailsPresenter extends ReferralLayoutPresenter {
   protected constructor(
     readonly referralDetails: ReferralDetails,
     readonly subNavValue: string,
-    readonly id: string,
-    readonly isCohortUpdated: boolean = false,
+    readonly isLdcUpdated: boolean | null = null,
+    readonly isCohortUpdated: boolean | null = null,
   ) {
-    super(HorizontalNavValues.referralDetailsTab, id, referralDetails.currentStatusDescription)
+    super(HorizontalNavValues.referralDetailsTab, referralDetails, isLdcUpdated, isCohortUpdated)
   }
 
   get referralSummary(): SummaryListArgs {
     return {
       ...ViewUtils.summaryListArgs(this.referralSummaryList(), { showBorders: false }, 'govuk-!-margin-bottom-0'),
-    }
-  }
-
-  get ldcUpdatedSuccessMessageArgs() {
-    return {
-      variant: 'success',
-      title: 'LDC status changed',
-      showTitleAsHeading: true,
-      dismissible: true,
-      text: `${this.referralDetails.personName} ${firstToLowerCase(this.referralDetails.hasLdcDisplayText)}`,
-    }
-  }
-
-  get cohortUpdatedSuccessMessageArgs() {
-    return {
-      variant: 'success',
-      title: 'Cohort changed',
-      showTitleAsHeading: true,
-      dismissible: true,
-      text: `${this.referralDetails.personName} is in the ${formatCohort(this.referralDetails.cohort)} cohort`,
     }
   }
 
@@ -59,7 +39,7 @@ export default class ReferralDetailsPresenter extends ReferralLayoutPresenter {
       items: [
         {
           text: 'Personal Details',
-          href: `/referral-details/${this.id}/personal-details/#personal-details`,
+          href: `/referral-details/${this.referralDetails.id}/personal-details/#personal-details`,
           active: this.subNavValue === ReferralDetailsPageSection.PersonalDetailsTab,
           attributes: {
             id: 'personal-details',
@@ -67,7 +47,7 @@ export default class ReferralDetailsPresenter extends ReferralLayoutPresenter {
         },
         {
           text: 'Programme History',
-          href: `/referral-details/${this.id}/programme-history/#programme-history`,
+          href: `/referral-details/${this.referralDetails.id}/programme-history/#programme-history`,
           active: this.subNavValue === ReferralDetailsPageSection.ProgrammeHistoryTab,
           attributes: {
             id: 'programme-history',
@@ -75,7 +55,7 @@ export default class ReferralDetailsPresenter extends ReferralLayoutPresenter {
         },
         {
           text: 'Offence History',
-          href: `/referral-details/${this.id}/offence-history/#offence-history`,
+          href: `/referral-details/${this.referralDetails.id}/offence-history/#offence-history`,
           active: this.subNavValue === ReferralDetailsPageSection.OffenceHistoryTab,
           attributes: {
             id: 'offence-history',
@@ -83,7 +63,7 @@ export default class ReferralDetailsPresenter extends ReferralLayoutPresenter {
         },
         {
           text: 'Sentence Information',
-          href: `/referral-details/${this.id}/sentence-information/#sentence-information`,
+          href: `/referral-details/${this.referralDetails.id}/sentence-information/#sentence-information`,
           active: this.subNavValue === ReferralDetailsPageSection.SentenceInformationTab,
           attributes: {
             id: 'sentence-information',
@@ -91,7 +71,7 @@ export default class ReferralDetailsPresenter extends ReferralLayoutPresenter {
         },
         {
           text: 'Availability',
-          href: `/referral-details/${this.id}/availability/#availability`,
+          href: `/referral-details/${this.referralDetails.id}/availability/#availability`,
           active: this.subNavValue === ReferralDetailsPageSection.AvailabilityTab,
           attributes: {
             id: 'availability',
@@ -99,7 +79,7 @@ export default class ReferralDetailsPresenter extends ReferralLayoutPresenter {
         },
         {
           text: 'Location',
-          href: `/referral-details/${this.id}/location/#location`,
+          href: `/referral-details/${this.referralDetails.id}/location/#location`,
           active: this.subNavValue === ReferralDetailsPageSection.LocationTab,
           attributes: {
             id: 'location',
@@ -107,7 +87,7 @@ export default class ReferralDetailsPresenter extends ReferralLayoutPresenter {
         },
         {
           text: 'Additional Information',
-          href: `/referral-details/${this.id}/additional-information/#additional-information`,
+          href: `/referral-details/${this.referralDetails.id}/additional-information/#additional-information`,
           active: this.subNavValue === ReferralDetailsPageSection.AdditionalInformationTab,
           attributes: {
             id: 'additional-information',

--- a/server/referralDetails/referralDetailsView.ts
+++ b/server/referralDetails/referralDetailsView.ts
@@ -1,5 +1,4 @@
 import ReferralDetailsPresenter from './referralDetailsPresenter'
-import { formatCohort } from '../utils/utils'
 
 export default class ReferralDetailsView {
   constructor(private readonly presenter: ReferralDetailsPresenter) {}
@@ -9,19 +8,7 @@ export default class ReferralDetailsView {
       'referralDetails/referralDetails',
       {
         presenter: this.presenter,
-        successMessageArgs: this.cohortUpdatedSuccessMessageArgs,
-        isCohortUpdated: this.presenter.isCohortUpdated,
       },
     ]
-  }
-
-  private cohortUpdatedSuccessMessageArgs() {
-    return {
-      variant: 'success',
-      title: 'Cohort changed',
-      showTitleAsHeading: true,
-      dismissible: true,
-      text: `${this.presenter.referralDetails.personName} is in the ${formatCohort(this.presenter.referralDetails.cohort)} cohort`,
-    }
   }
 }

--- a/server/referralDetails/sentenceInformationPresenter.test.ts
+++ b/server/referralDetails/sentenceInformationPresenter.test.ts
@@ -1,20 +1,13 @@
-import { randomUUID } from 'crypto'
 import SentenceInformationPresenter from './sentenceInformationPresenter'
 import referralDetailsFactory from '../testutils/factories/referralDetailsFactory'
 import sentenceInformationFactory from '../testutils/factories/sentenceInformationFactory'
 
 describe(`sentenceInformationSummaryList.`, () => {
   it('a licence referral will show the correct rows', () => {
-    const referralId = randomUUID()
     const referralDetails = referralDetailsFactory.build()
     const sentenceInformation = sentenceInformationFactory.licence().build()
 
-    const presenter = new SentenceInformationPresenter(
-      referralDetails,
-      'sentence-information',
-      referralId,
-      sentenceInformation,
-    )
+    const presenter = new SentenceInformationPresenter(referralDetails, 'sentence-information', sentenceInformation)
 
     const expectedResult = [
       {
@@ -51,7 +44,6 @@ describe(`sentenceInformationSummaryList.`, () => {
   })
 
   it(`a licence referral will show 'Data not available' for null rows`, () => {
-    const referralId = randomUUID()
     const referralDetails = referralDetailsFactory.build()
     const sentenceInformation = sentenceInformationFactory.licence().build({
       sentenceType: null,
@@ -63,12 +55,7 @@ describe(`sentenceInformationSummaryList.`, () => {
       twoThirdsPoint: null,
     })
 
-    const presenter = new SentenceInformationPresenter(
-      referralDetails,
-      'sentence-information',
-      referralId,
-      sentenceInformation,
-    )
+    const presenter = new SentenceInformationPresenter(referralDetails, 'sentence-information', sentenceInformation)
 
     const expectedResult = [
       {
@@ -105,16 +92,10 @@ describe(`sentenceInformationSummaryList.`, () => {
   })
 
   it(`an order referral will show 'Data not available' for null rows`, () => {
-    const referralId = randomUUID()
     const referralDetails = referralDetailsFactory.build()
     const sentenceInformation = sentenceInformationFactory.order().build()
 
-    const presenter = new SentenceInformationPresenter(
-      referralDetails,
-      'sentence-information',
-      referralId,
-      sentenceInformation,
-    )
+    const presenter = new SentenceInformationPresenter(referralDetails, 'sentence-information', sentenceInformation)
 
     const expectedResult = [
       {
@@ -135,16 +116,10 @@ describe(`sentenceInformationSummaryList.`, () => {
   })
 
   it('an order referral will show the correct rows', () => {
-    const referralId = randomUUID()
     const referralDetails = referralDetailsFactory.build()
     const sentenceInformation = sentenceInformationFactory.order().build({ sentenceType: null, orderEndDate: null })
 
-    const presenter = new SentenceInformationPresenter(
-      referralDetails,
-      'sentence-information',
-      referralId,
-      sentenceInformation,
-    )
+    const presenter = new SentenceInformationPresenter(referralDetails, 'sentence-information', sentenceInformation)
 
     const expectedResult = [
       {

--- a/server/referralDetails/sentenceInformationPresenter.ts
+++ b/server/referralDetails/sentenceInformationPresenter.ts
@@ -6,10 +6,11 @@ export default class SentenceInformationPresenter extends ReferralDetailsPresent
   constructor(
     readonly details: ReferralDetails,
     readonly subNavValue: string,
-    readonly id: string,
     readonly sentenceInformation: SentenceInformation,
+    readonly isLdcUpdated: boolean | null = null,
+    readonly isCohortUpdated: boolean | null = null,
   ) {
-    super(details, subNavValue, id)
+    super(details, subNavValue, isLdcUpdated, isCohortUpdated)
   }
 
   orderSummaryList(): SummaryListItem[] {

--- a/server/risksAndNeeds/alcoholMisuse/alcoholMisusePresenter.ts
+++ b/server/risksAndNeeds/alcoholMisuse/alcoholMisusePresenter.ts
@@ -1,15 +1,16 @@
-import { AlcoholMisuseDetails } from '@manage-and-deliver-api'
+import { AlcoholMisuseDetails, ReferralDetails } from '@manage-and-deliver-api'
 import RisksAndNeedsPresenter from '../risksAndNeedsPresenter'
 import { SummaryListItem } from '../../utils/summaryList'
 
 export default class AlcoholMisusePresenter extends RisksAndNeedsPresenter {
   constructor(
     readonly subNavValue: string,
-    readonly referralId: string,
+    readonly referral: ReferralDetails,
     readonly alcoholMisuseDetails: AlcoholMisuseDetails,
-    readonly referralStatus: string,
+    readonly isLdcUpdated: boolean | null = null,
+    readonly isCohortUpdated: boolean | null = null,
   ) {
-    super(subNavValue, referralId, referralStatus)
+    super(subNavValue, referral, isLdcUpdated, isCohortUpdated)
   }
 
   alcoholMisuseSummaryList(): SummaryListItem[] {

--- a/server/risksAndNeeds/attitudes/attitudesPresenter.ts
+++ b/server/risksAndNeeds/attitudes/attitudesPresenter.ts
@@ -1,15 +1,16 @@
-import { Attitude } from '@manage-and-deliver-api'
+import { Attitude, ReferralDetails } from '@manage-and-deliver-api'
 import RisksAndNeedsPresenter from '../risksAndNeedsPresenter'
 import { SummaryListItem } from '../../utils/summaryList'
 
 export default class AttitudesPresenter extends RisksAndNeedsPresenter {
   constructor(
     readonly subNavValue: string,
-    readonly referralId: string,
+    readonly referral: ReferralDetails,
     readonly attitude: Attitude,
-    readonly referralStatus: string,
+    readonly isLdcUpdated: boolean | null = null,
+    readonly isCohortUpdated: boolean | null = null,
   ) {
-    super(subNavValue, referralId, referralStatus)
+    super(subNavValue, referral, isLdcUpdated, isCohortUpdated)
   }
 
   attitudeSummaryList(): SummaryListItem[] {

--- a/server/risksAndNeeds/drugMisuse/drugDetailsPresenter.ts
+++ b/server/risksAndNeeds/drugMisuse/drugDetailsPresenter.ts
@@ -1,15 +1,16 @@
-import { DrugDetails } from '@manage-and-deliver-api'
+import { DrugDetails, ReferralDetails } from '@manage-and-deliver-api'
 import RisksAndNeedsPresenter from '../risksAndNeedsPresenter'
 import { SummaryListItem } from '../../utils/summaryList'
 
 export default class DrugDetailsPresenter extends RisksAndNeedsPresenter {
   constructor(
     readonly subNavValue: string,
-    readonly referralId: string,
+    readonly referral: ReferralDetails,
     readonly drugDetails: DrugDetails,
-    readonly referralStatus: string,
+    readonly isLdcUpdated: boolean | null = null,
+    readonly isCohortUpdated: boolean | null = null,
   ) {
-    super(subNavValue, referralId, referralStatus)
+    super(subNavValue, referral, isLdcUpdated, isCohortUpdated)
   }
 
   drugDetailsSummaryList(): SummaryListItem[] {

--- a/server/risksAndNeeds/emotionalWellbeing/emotionalWellbeingPresenter.ts
+++ b/server/risksAndNeeds/emotionalWellbeing/emotionalWellbeingPresenter.ts
@@ -1,15 +1,16 @@
-import { EmotionalWellbeing } from '@manage-and-deliver-api'
+import { EmotionalWellbeing, ReferralDetails } from '@manage-and-deliver-api'
 import RisksAndNeedsPresenter from '../risksAndNeedsPresenter'
 import { SummaryListItem } from '../../utils/summaryList'
 
 export default class EmotionalWellbeingPresenter extends RisksAndNeedsPresenter {
   constructor(
     readonly subNavValue: string,
-    readonly referralId: string,
-    readonly referralStatus: string,
+    readonly referral: ReferralDetails,
+    readonly isLdcUpdated: boolean | null = null,
+    readonly isCohortUpdated: boolean | null = null,
     readonly emotionalWellbeing?: EmotionalWellbeing,
   ) {
-    super(subNavValue, referralId, referralStatus)
+    super(subNavValue, referral, isLdcUpdated, isCohortUpdated)
   }
 
   emotionalWellbeingSummaryList(): SummaryListItem[] {

--- a/server/risksAndNeeds/health/healthPresenter.ts
+++ b/server/risksAndNeeds/health/healthPresenter.ts
@@ -1,15 +1,16 @@
-import { Health } from '@manage-and-deliver-api'
+import { Health, ReferralDetails } from '@manage-and-deliver-api'
 import RisksAndNeedsPresenter from '../risksAndNeedsPresenter'
 import { SummaryListItem } from '../../utils/summaryList'
 
 export default class HealthPresenter extends RisksAndNeedsPresenter {
   constructor(
     readonly subNavValue: string,
-    readonly referralId: string,
+    readonly referral: ReferralDetails,
     readonly health: Health,
-    readonly referralStatus: string,
+    readonly isLdcUpdated: boolean | null = null,
+    readonly isCohortUpdated: boolean | null = null,
   ) {
-    super(subNavValue, referralId, referralStatus)
+    super(subNavValue, referral, isLdcUpdated, isCohortUpdated)
   }
 
   healthSummaryList(): SummaryListItem[] {

--- a/server/risksAndNeeds/learningNeeds/learningNeedsPresenter.ts
+++ b/server/risksAndNeeds/learningNeeds/learningNeedsPresenter.ts
@@ -1,4 +1,4 @@
-import { LearningNeeds } from '@manage-and-deliver-api'
+import { LearningNeeds, ReferralDetails } from '@manage-and-deliver-api'
 import RisksAndNeedsPresenter from '../risksAndNeedsPresenter'
 import { SummaryListItem } from '../../utils/summaryList'
 import PresenterUtils from '../../utils/presenterUtils'
@@ -6,11 +6,12 @@ import PresenterUtils from '../../utils/presenterUtils'
 export default class LearningNeedsPresenter extends RisksAndNeedsPresenter {
   constructor(
     readonly subNavValue: string,
-    readonly referralId: string,
+    readonly referral: ReferralDetails,
     readonly learningNeeds: LearningNeeds,
-    readonly referralStatus: string,
+    readonly isLdcUpdated: boolean | null = null,
+    readonly isCohortUpdated: boolean | null = null,
   ) {
-    super(subNavValue, referralId, referralStatus)
+    super(subNavValue, referral, isLdcUpdated, isCohortUpdated)
   }
 
   learningNeedsSummaryList(): SummaryListItem[] {

--- a/server/risksAndNeeds/lifestyleAndAssociates/lifestyleAndAssociatesPresenter.test.ts
+++ b/server/risksAndNeeds/lifestyleAndAssociates/lifestyleAndAssociatesPresenter.test.ts
@@ -1,16 +1,12 @@
-import { randomUUID } from 'crypto'
 import lifestyleAndAssociatesFactory from '../../testutils/factories/risksAndNeeds/lifestyleAndAssociatesFactory'
 import LifestyleAndAssociatesPresenter from './lifestyleAndAssociatesPresenter'
+import referralDetailsFactory from '../../testutils/factories/referralDetailsFactory'
 
 describe(`reoffendingSummaryList.`, () => {
   it('should generate the table correctly from the values supplied', () => {
     const lifestyleAndAssociates = lifestyleAndAssociatesFactory.build()
-    const presenter = new LifestyleAndAssociatesPresenter(
-      'lifestyleAndAssociates',
-      randomUUID(),
-      lifestyleAndAssociates,
-      'Awaiting assessment',
-    )
+    const referral = referralDetailsFactory.build()
+    const presenter = new LifestyleAndAssociatesPresenter('lifestyleAndAssociates', referral, lifestyleAndAssociates)
 
     expect(presenter.reoffendingSummaryList()).toEqual([
       {
@@ -24,12 +20,8 @@ describe(`reoffendingSummaryList.`, () => {
 describe(`lifestyleIssuesSummaryList.`, () => {
   it('should generate the table correctly from the values supplied', () => {
     const lifestyleAndAssociates = lifestyleAndAssociatesFactory.build()
-    const presenter = new LifestyleAndAssociatesPresenter(
-      'lifestyleAndAssociates',
-      randomUUID(),
-      lifestyleAndAssociates,
-      'Awaiting assessment',
-    )
+    const referral = referralDetailsFactory.build()
+    const presenter = new LifestyleAndAssociatesPresenter('lifestyleAndAssociates', referral, lifestyleAndAssociates)
 
     expect(presenter.lifestyleIssuesSummaryList()).toEqual([
       {

--- a/server/risksAndNeeds/lifestyleAndAssociates/lifestyleAndAssociatesPresenter.ts
+++ b/server/risksAndNeeds/lifestyleAndAssociates/lifestyleAndAssociatesPresenter.ts
@@ -1,15 +1,16 @@
-import { LifestyleAndAssociates } from '@manage-and-deliver-api'
+import { LifestyleAndAssociates, ReferralDetails } from '@manage-and-deliver-api'
 import RisksAndNeedsPresenter from '../risksAndNeedsPresenter'
 import { SummaryListItem } from '../../utils/summaryList'
 
 export default class LifestyleAndAssociatesPresenter extends RisksAndNeedsPresenter {
   constructor(
     readonly subNavValue: string,
-    readonly referralId: string,
+    readonly referral: ReferralDetails,
     readonly lifestyleAndAssociates: LifestyleAndAssociates,
-    readonly referralStatus: string,
+    readonly isLdcUpdated: boolean | null = null,
+    readonly isCohortUpdated: boolean | null = null,
   ) {
-    super(subNavValue, referralId, referralStatus)
+    super(subNavValue, referral, isLdcUpdated, isCohortUpdated)
   }
 
   reoffendingSummaryList(): SummaryListItem[] {

--- a/server/risksAndNeeds/offenceAnalysis/offenceAnalysisPresenter.ts
+++ b/server/risksAndNeeds/offenceAnalysis/offenceAnalysisPresenter.ts
@@ -1,4 +1,4 @@
-import { OffenceAnalysis } from '@manage-and-deliver-api'
+import { OffenceAnalysis, ReferralDetails } from '@manage-and-deliver-api'
 import { InsetTextArgs } from '../../utils/govukFrontendTypes'
 import { SummaryListItem } from '../../utils/summaryList'
 import RisksAndNeedsPresenter from '../risksAndNeedsPresenter'
@@ -6,11 +6,12 @@ import RisksAndNeedsPresenter from '../risksAndNeedsPresenter'
 export default class OffenceAnalysisPresenter extends RisksAndNeedsPresenter {
   constructor(
     readonly subNavValue: string,
-    readonly referralId: string,
+    readonly referral: ReferralDetails,
     readonly offenceAnalysis: OffenceAnalysis,
-    readonly referralStatus: string,
+    readonly isLdcUpdated: boolean | null = null,
+    readonly isCohortUpdated: boolean | null = null,
   ) {
-    super(subNavValue, referralId, referralStatus)
+    super(subNavValue, referral, isLdcUpdated, isCohortUpdated)
   }
 
   get assessmentCompletedText(): InsetTextArgs {

--- a/server/risksAndNeeds/relationships/relationshipsPresenter.ts
+++ b/server/risksAndNeeds/relationships/relationshipsPresenter.ts
@@ -1,4 +1,4 @@
-import { Relationships } from '@manage-and-deliver-api'
+import { ReferralDetails, Relationships } from '@manage-and-deliver-api'
 import RisksAndNeedsPresenter from '../risksAndNeedsPresenter'
 import { SummaryListItem } from '../../utils/summaryList'
 import PresenterUtils from '../../utils/presenterUtils'
@@ -6,11 +6,12 @@ import PresenterUtils from '../../utils/presenterUtils'
 export default class RelationshipsPresenter extends RisksAndNeedsPresenter {
   constructor(
     readonly subNavValue: string,
-    readonly referralId: string,
+    readonly referral: ReferralDetails,
     readonly relationships: Relationships,
-    readonly referralStatus: string,
+    readonly isLdcUpdated: boolean | null = null,
+    readonly isCohortUpdated: boolean | null = null,
   ) {
-    super(subNavValue, referralId, referralStatus)
+    super(subNavValue, referral, isLdcUpdated, isCohortUpdated)
   }
 
   relationshipsSummaryList(): SummaryListItem[] {

--- a/server/risksAndNeeds/risksAndAlerts/risksAndAlertsPresenter.test.ts
+++ b/server/risksAndNeeds/risksAndAlerts/risksAndAlertsPresenter.test.ts
@@ -1,10 +1,11 @@
-import { randomUUID } from 'crypto'
 import risksFactory from '../../testutils/factories/risksAndNeeds/risksFactory'
 import RisksAndAlertsPresenter, { RiskLevel } from './risksAndAlertsPresenter'
+import referralDetailsFactory from '../../testutils/factories/referralDetailsFactory'
 
 describe(`getLevelClass.`, () => {
   const risks = risksFactory.build()
-  const presenter = new RisksAndAlertsPresenter('risksAndAlerts', randomUUID(), risks, 'Awaiting assessment')
+  const referral = referralDetailsFactory.build()
+  const presenter = new RisksAndAlertsPresenter('risksAndAlerts', referral, risks)
 
   test.each([
     { input: 'LOW', expectedResult: 'risk-box--low' },
@@ -24,7 +25,8 @@ describe(`getLevelClass.`, () => {
 
 describe(`getLevelText.`, () => {
   const risks = risksFactory.build()
-  const presenter = new RisksAndAlertsPresenter('risksAndAlerts', randomUUID(), risks, 'Awaiting assessment')
+  const referral = referralDetailsFactory.build()
+  const presenter = new RisksAndAlertsPresenter('risksAndAlerts', referral, risks)
 
   test.each([
     { input: 'LOW', expectedResult: 'LOW' },
@@ -60,14 +62,16 @@ describe(`getLevelText.`, () => {
 describe(`formatFigure.`, () => {
   it('should correctly format the figure with a % symbol', () => {
     const risks = risksFactory.build()
-    const presenter = new RisksAndAlertsPresenter('risksAndAlerts', randomUUID(), risks, 'Awaiting assessment')
+    const referral = referralDetailsFactory.build()
+    const presenter = new RisksAndAlertsPresenter('risksAndAlerts', referral, risks)
 
     expect(presenter.formatFigure(2)).toEqual('2%')
   })
 
   it('should return undefined if the figure input is not provided', () => {
     const risks = risksFactory.build()
-    const presenter = new RisksAndAlertsPresenter('risksAndAlerts', randomUUID(), risks, 'Awaiting assessment')
+    const referral = referralDetailsFactory.build()
+    const presenter = new RisksAndAlertsPresenter('risksAndAlerts', referral, risks)
 
     expect(presenter.formatFigure(null)).toEqual(undefined)
   })
@@ -76,7 +80,8 @@ describe(`formatFigure.`, () => {
 describe(`getBodyHtmlStringWithClass.`, () => {
   it('should return the correct string based on the input', () => {
     const risks = risksFactory.build()
-    const presenter = new RisksAndAlertsPresenter('risksAndAlerts', randomUUID(), risks, 'Awaiting assessment')
+    const referral = referralDetailsFactory.build()
+    const presenter = new RisksAndAlertsPresenter('risksAndAlerts', referral, risks)
 
     expect(presenter.getBodyHtmlStringWithClass('A random string')).toEqual(
       `<p class="govuk-body-m govuk-!-margin-bottom-0">A random string</p>`,
@@ -87,7 +92,8 @@ describe(`getBodyHtmlStringWithClass.`, () => {
 describe(`getLastUpdatedStringWithClass.`, () => {
   it('should return the correct string based on the input', () => {
     const risks = risksFactory.build()
-    const presenter = new RisksAndAlertsPresenter('risksAndAlerts', randomUUID(), risks, 'Awaiting assessment')
+    const referral = referralDetailsFactory.build()
+    const presenter = new RisksAndAlertsPresenter('risksAndAlerts', referral, risks)
 
     expect(presenter.getLastUpdatedStringWithClass('12th October 2024')).toEqual(
       `<p class="risk-box__body-text govuk-!-margin-bottom-0">Last updated: 12th October 2024</p>`,
@@ -97,7 +103,8 @@ describe(`getLastUpdatedStringWithClass.`, () => {
 
 describe(`roshTableCellForLevel.`, () => {
   const risks = risksFactory.build()
-  const presenter = new RisksAndAlertsPresenter('risksAndAlerts', randomUUID(), risks, 'Awaiting assessment')
+  const referral = referralDetailsFactory.build()
+  const presenter = new RisksAndAlertsPresenter('risksAndAlerts', referral, risks)
 
   test.each([
     { input: 'LOW', expectedResult: { classes: `rosh-table__cell rosh-table__cell--low`, text: 'Low' } },

--- a/server/risksAndNeeds/risksAndAlerts/risksAndAlertsPresenter.ts
+++ b/server/risksAndNeeds/risksAndAlerts/risksAndAlertsPresenter.ts
@@ -1,4 +1,4 @@
-import { Risks } from '@manage-and-deliver-api'
+import { ReferralDetails, Risks } from '@manage-and-deliver-api'
 import { GovukFrontendTableCell } from '../../@types/govukFrontend'
 import RisksAndNeedsPresenter from '../risksAndNeedsPresenter'
 
@@ -31,11 +31,12 @@ export type ActiveAlerts = {
 export default class RisksAndAlertsPresenter extends RisksAndNeedsPresenter {
   constructor(
     readonly subNavValue: string,
-    readonly referralId: string,
+    readonly referral: ReferralDetails,
     readonly risks: Risks,
-    readonly referralStatus: string,
+    readonly isLdcUpdated: boolean | null = null,
+    readonly isCohortUpdated: boolean | null = null,
   ) {
-    super(subNavValue, referralId, referralStatus)
+    super(subNavValue, referral, isLdcUpdated, isCohortUpdated)
   }
 
   getLevelClass(scoreLevel: RiskLevel): string {

--- a/server/risksAndNeeds/risksAndNeedsController.ts
+++ b/server/risksAndNeeds/risksAndNeedsController.ts
@@ -40,6 +40,7 @@ export default class RisksAndNeedsController {
   async showRisksAndAlertsPage(req: Request, res: Response): Promise<void> {
     const { referralId } = req.params
     const { username } = req.user
+    const { isCohortUpdated, isLdcUpdated } = req.query
     const subNavValue = 'risksAndAlerts'
 
     const sharedReferralDetailsData = await this.getSharedPageData(referralId, username)
@@ -47,15 +48,17 @@ export default class RisksAndNeedsController {
       username,
       sharedReferralDetailsData.crn,
     )
+
     const presenter = new RisksAndAlertsPresenter(
       subNavValue,
-      referralId,
+      sharedReferralDetailsData,
       risks,
-      sharedReferralDetailsData.currentStatusDescription,
+      isLdcUpdated === 'true',
+      isCohortUpdated === 'true',
     )
     const view = new RisksAndAlertsView(presenter)
 
-    req.session.originPage = req.originalUrl
+    req.session.originPage = req.path
 
     return ControllerUtils.renderWithLayout(res, view, sharedReferralDetailsData)
   }
@@ -63,6 +66,7 @@ export default class RisksAndNeedsController {
   async showLearningNeedsPage(req: Request, res: Response): Promise<void> {
     const { referralId } = req.params
     const { username } = req.user
+    const { isCohortUpdated, isLdcUpdated } = req.query
     const subNavValue = 'learningNeeds'
 
     const sharedReferralDetailsData = await this.getSharedPageData(referralId, username)
@@ -72,11 +76,14 @@ export default class RisksAndNeedsController {
     )
     const presenter = new LearningNeedsPresenter(
       subNavValue,
-      referralId,
+      sharedReferralDetailsData,
       learningNeeds,
-      sharedReferralDetailsData.currentStatusDescription,
+      isLdcUpdated === 'true',
+      isCohortUpdated === 'true',
     )
     const view = new LearningNeedsView(presenter)
+
+    req.session.originPage = req.path
 
     ControllerUtils.renderWithLayout(res, view, sharedReferralDetailsData)
   }
@@ -84,6 +91,7 @@ export default class RisksAndNeedsController {
   async showOffenceAnalysisPage(req: Request, res: Response): Promise<void> {
     const { referralId } = req.params
     const { username } = req.user
+    const { isCohortUpdated, isLdcUpdated } = req.query
     const subNavValue = 'offenceAnalysis'
 
     const sharedReferralDetailsData = await this.getSharedPageData(referralId, username)
@@ -94,11 +102,14 @@ export default class RisksAndNeedsController {
 
     const presenter = new OffenceAnalysisPresenter(
       subNavValue,
-      referralId,
+      sharedReferralDetailsData,
       offenceAnalysis,
-      sharedReferralDetailsData.currentStatusDescription,
+      isLdcUpdated === 'true',
+      isCohortUpdated === 'true',
     )
     const view = new OffenceAnalysisView(presenter)
+
+    req.session.originPage = req.path
 
     ControllerUtils.renderWithLayout(res, view, sharedReferralDetailsData)
   }
@@ -106,6 +117,7 @@ export default class RisksAndNeedsController {
   async showRelationshipsPage(req: Request, res: Response): Promise<void> {
     const { referralId } = req.params
     const { username } = req.user
+    const { isCohortUpdated, isLdcUpdated } = req.query
     const subNavValue = 'relationships'
 
     const sharedReferralDetailsData = await this.getSharedPageData(referralId, username)
@@ -116,11 +128,14 @@ export default class RisksAndNeedsController {
 
     const presenter = new RelationshipsPresenter(
       subNavValue,
-      referralId,
+      sharedReferralDetailsData,
       relationships,
-      sharedReferralDetailsData.currentStatusDescription,
+      isLdcUpdated === 'true',
+      isCohortUpdated === 'true',
     )
     const view = new RelationshipsView(presenter)
+
+    req.session.originPage = req.path
 
     ControllerUtils.renderWithLayout(res, view, sharedReferralDetailsData)
   }
@@ -128,6 +143,7 @@ export default class RisksAndNeedsController {
   async showLifestyleAndAssociatesPage(req: Request, res: Response): Promise<void> {
     const { referralId } = req.params
     const { username } = req.user
+    const { isCohortUpdated, isLdcUpdated } = req.query
     const subNavValue = 'lifestyleAndAssociates'
 
     const sharedReferralDetailsData = await this.getSharedPageData(referralId, username)
@@ -138,11 +154,14 @@ export default class RisksAndNeedsController {
 
     const presenter = new LifestyleAndAssociatesPresenter(
       subNavValue,
-      referralId,
+      sharedReferralDetailsData,
       lifestyleAndAssociates,
-      sharedReferralDetailsData.currentStatusDescription,
+      isLdcUpdated === 'true',
+      isCohortUpdated === 'true',
     )
     const view = new LifestyleAndAssociatesView(presenter)
+
+    req.session.originPage = req.path
 
     ControllerUtils.renderWithLayout(res, view, sharedReferralDetailsData)
   }
@@ -150,6 +169,7 @@ export default class RisksAndNeedsController {
   async showAlcoholMisusePage(req: Request, res: Response): Promise<void> {
     const { referralId } = req.params
     const { username } = req.user
+    const { isCohortUpdated, isLdcUpdated } = req.query
     const subNavValue = 'alcoholMisuse'
 
     const sharedReferralDetailsData = await this.getSharedPageData(referralId, username)
@@ -160,11 +180,14 @@ export default class RisksAndNeedsController {
 
     const presenter = new AlcoholMisusePresenter(
       subNavValue,
-      referralId,
+      sharedReferralDetailsData,
       alcoholMisuseDetails,
-      sharedReferralDetailsData.currentStatusDescription,
+      isLdcUpdated === 'true',
+      isCohortUpdated === 'true',
     )
     const view = new AlcoholMisuseView(presenter)
+
+    req.session.originPage = req.path
 
     ControllerUtils.renderWithLayout(res, view, sharedReferralDetailsData)
   }
@@ -172,6 +195,7 @@ export default class RisksAndNeedsController {
   async showEmotionalWellbeingPage(req: Request, res: Response): Promise<void> {
     const { referralId } = req.params
     const { username } = req.user
+    const { isCohortUpdated, isLdcUpdated } = req.query
     const subNavValue = 'emotionalWellbeing'
 
     const sharedReferralDetailsData = await this.getSharedPageData(referralId, username)
@@ -183,11 +207,14 @@ export default class RisksAndNeedsController {
 
     const presenter = new EmotionalWellbeingPresenter(
       subNavValue,
-      referralId,
-      sharedReferralDetailsData.currentStatusDescription,
+      sharedReferralDetailsData,
+      isLdcUpdated === 'true',
+      isCohortUpdated === 'true',
       emotionalWellbeing,
     )
     const view = new EmotionalWellbeingView(presenter)
+
+    req.session.originPage = req.path
 
     ControllerUtils.renderWithLayout(res, view, sharedReferralDetailsData)
   }
@@ -195,6 +222,7 @@ export default class RisksAndNeedsController {
   async showThinkingAndBehavingPage(req: Request, res: Response): Promise<void> {
     const { referralId } = req.params
     const { username } = req.user
+    const { isCohortUpdated, isLdcUpdated } = req.query
     const subNavValue = 'thinkingAndBehaviour'
 
     const sharedReferralDetailsData = await this.getSharedPageData(referralId, username)
@@ -206,11 +234,14 @@ export default class RisksAndNeedsController {
 
     const presenter = new ThinkingAndBehavingPresenter(
       subNavValue,
-      referralId,
-      sharedReferralDetailsData.currentStatusDescription,
+      sharedReferralDetailsData,
+      isLdcUpdated === 'true',
+      isCohortUpdated === 'true',
       thinkingAndBehaviour,
     )
     const view = new ThinkingAndBehavingView(presenter)
+
+    req.session.originPage = req.path
 
     ControllerUtils.renderWithLayout(res, view, sharedReferralDetailsData)
   }
@@ -218,6 +249,7 @@ export default class RisksAndNeedsController {
   async showAttitudesPage(req: Request, res: Response): Promise<void> {
     const { referralId } = req.params
     const { username } = req.user
+    const { isCohortUpdated, isLdcUpdated } = req.query
     const subNavValue = 'attitudes'
 
     const sharedReferralDetailsData = await this.getSharedPageData(referralId, username)
@@ -228,11 +260,14 @@ export default class RisksAndNeedsController {
 
     const presenter = new AttitudesPresenter(
       subNavValue,
-      referralId,
+      sharedReferralDetailsData,
       attitudes,
-      sharedReferralDetailsData.currentStatusDescription,
+      isLdcUpdated === 'true',
+      isCohortUpdated === 'true',
     )
     const view = new AttitudesView(presenter)
+
+    req.session.originPage = req.path
 
     ControllerUtils.renderWithLayout(res, view, sharedReferralDetailsData)
   }
@@ -240,6 +275,7 @@ export default class RisksAndNeedsController {
   async showHealthPage(req: Request, res: Response): Promise<void> {
     const { referralId } = req.params
     const { username } = req.user
+    const { isCohortUpdated, isLdcUpdated } = req.query
     const subNavValue = 'health'
 
     const sharedReferralDetailsData = await this.getSharedPageData(referralId, username)
@@ -250,11 +286,14 @@ export default class RisksAndNeedsController {
 
     const presenter = new HealthPresenter(
       subNavValue,
-      referralId,
+      sharedReferralDetailsData,
       health,
-      sharedReferralDetailsData.currentStatusDescription,
+      isLdcUpdated === 'true',
+      isCohortUpdated === 'true',
     )
     const view = new HealthView(presenter)
+
+    req.session.originPage = req.path
 
     ControllerUtils.renderWithLayout(res, view, sharedReferralDetailsData)
   }
@@ -262,6 +301,7 @@ export default class RisksAndNeedsController {
   async showDrugDetailsPage(req: Request, res: Response): Promise<void> {
     const { referralId } = req.params
     const { username } = req.user
+    const { isCohortUpdated, isLdcUpdated } = req.query
     const subNavValue = 'drugMisuse'
 
     const sharedReferralDetailsData = await this.getSharedPageData(referralId, username)
@@ -272,11 +312,14 @@ export default class RisksAndNeedsController {
 
     const presenter = new DrugDetailsPresenter(
       subNavValue,
-      referralId,
+      sharedReferralDetailsData,
       drugDetails,
-      sharedReferralDetailsData.currentStatusDescription,
+      isLdcUpdated === 'true',
+      isCohortUpdated === 'true',
     )
     const view = new DrugDetailsView(presenter)
+
+    req.session.originPage = req.path
 
     ControllerUtils.renderWithLayout(res, view, sharedReferralDetailsData)
   }
@@ -284,6 +327,7 @@ export default class RisksAndNeedsController {
   async showRoshAnalysisPage(req: Request, res: Response): Promise<void> {
     const { referralId } = req.params
     const { username } = req.user
+    const { isCohortUpdated, isLdcUpdated } = req.query
     const subNavValue = 'roshAnalysis'
 
     const sharedReferralDetailsData = await this.getSharedPageData(referralId, username)
@@ -294,11 +338,14 @@ export default class RisksAndNeedsController {
 
     const presenter = new RoshAnalysisPresenter(
       subNavValue,
-      referralId,
+      sharedReferralDetailsData,
       roshAnalysis,
-      sharedReferralDetailsData.currentStatusDescription,
+      isLdcUpdated === 'true',
+      isCohortUpdated === 'true',
     )
     const view = new RoshAnalysisView(presenter)
+
+    req.session.originPage = req.path
 
     ControllerUtils.renderWithLayout(res, view, sharedReferralDetailsData)
   }

--- a/server/risksAndNeeds/risksAndNeedsPresenter.ts
+++ b/server/risksAndNeeds/risksAndNeedsPresenter.ts
@@ -1,3 +1,4 @@
+import { ReferralDetails } from '@manage-and-deliver-api'
 import ReferralLayoutPresenter, { HorizontalNavValues } from '../shared/referral/referralLayoutPresenter'
 
 export enum RisksAndNeedsPageSection {
@@ -18,10 +19,11 @@ export enum RisksAndNeedsPageSection {
 export default class RisksAndNeedsPresenter extends ReferralLayoutPresenter {
   constructor(
     readonly subNavValue: string,
-    readonly referralId: string,
-    readonly referralStatus: string,
+    readonly referral: ReferralDetails,
+    readonly isLdcUpdated: boolean | null = null,
+    readonly isCohortUpdated: boolean | null = null,
   ) {
-    super(HorizontalNavValues.risksAndNeedsTab, referralId, referralStatus)
+    super(HorizontalNavValues.risksAndNeedsTab, referral, isLdcUpdated, isCohortUpdated)
   }
 
   readonly pageDescription =
@@ -35,7 +37,7 @@ export default class RisksAndNeedsPresenter extends ReferralLayoutPresenter {
       items: [
         {
           text: 'Risks and alerts',
-          href: `/referral/${this.referralId}/risks-and-alerts/#risks-and-alerts`,
+          href: `/referral/${this.referral.id}/risks-and-alerts/#risks-and-alerts`,
           active: this.subNavValue === RisksAndNeedsPageSection.RisksAndAlertsTab,
           attributes: {
             id: 'risks-and-alerts',
@@ -43,7 +45,7 @@ export default class RisksAndNeedsPresenter extends ReferralLayoutPresenter {
         },
         {
           text: 'Learning needs',
-          href: `/referral/${this.referralId}/learning-needs/#learning-needs`,
+          href: `/referral/${this.referral.id}/learning-needs/#learning-needs`,
           active: this.subNavValue === RisksAndNeedsPageSection.LearningNeedsTab,
           attributes: {
             id: 'learning-needs',
@@ -51,7 +53,7 @@ export default class RisksAndNeedsPresenter extends ReferralLayoutPresenter {
         },
         {
           text: 'Section 2 - Offence analysis',
-          href: `/referral/${this.referralId}/offence-analysis/#section-2-offence-analysis`,
+          href: `/referral/${this.referral.id}/offence-analysis/#section-2-offence-analysis`,
           active: this.subNavValue === RisksAndNeedsPageSection.Section2OffenceAnalysisTab,
           attributes: {
             id: 'section-2-offence-analysis',
@@ -59,7 +61,7 @@ export default class RisksAndNeedsPresenter extends ReferralLayoutPresenter {
         },
         {
           text: 'Section 6 - Relationships',
-          href: `/referral/${this.referralId}/relationships/#section-6-relationships`,
+          href: `/referral/${this.referral.id}/relationships/#section-6-relationships`,
           active: this.subNavValue === RisksAndNeedsPageSection.Section6RelationshipsTab,
           attributes: {
             id: 'section-6-relationships',
@@ -67,7 +69,7 @@ export default class RisksAndNeedsPresenter extends ReferralLayoutPresenter {
         },
         {
           text: 'Section 7 - Lifestyle and associates',
-          href: `/referral/${this.referralId}/lifestyle-and-associates/#section-7-lifestyle-and-associates`,
+          href: `/referral/${this.referral.id}/lifestyle-and-associates/#section-7-lifestyle-and-associates`,
           active: this.subNavValue === RisksAndNeedsPageSection.Section7LifestyleAndAssociatesTab,
           attributes: {
             id: 'section-7-lifestyle-and-associates',
@@ -75,7 +77,7 @@ export default class RisksAndNeedsPresenter extends ReferralLayoutPresenter {
         },
         {
           text: 'Section 8 - Drug misuse',
-          href: `/referral/${this.referralId}/drug-misuse/#section-8-drug-misuse`,
+          href: `/referral/${this.referral.id}/drug-misuse/#section-8-drug-misuse`,
           active: this.subNavValue === RisksAndNeedsPageSection.Section8DrugMisuseTab,
           attributes: {
             id: 'section-8-drug-misuse',
@@ -83,7 +85,7 @@ export default class RisksAndNeedsPresenter extends ReferralLayoutPresenter {
         },
         {
           text: 'Section 9 - Alcohol misuse',
-          href: `/referral/${this.referralId}/alcohol-misuse/#section-9-alcohol-misuse`,
+          href: `/referral/${this.referral.id}/alcohol-misuse/#section-9-alcohol-misuse`,
           active: this.subNavValue === RisksAndNeedsPageSection.Section9AlcoholMisuseTab,
           attributes: {
             id: 'section-9-alcohol-misuse',
@@ -91,7 +93,7 @@ export default class RisksAndNeedsPresenter extends ReferralLayoutPresenter {
         },
         {
           text: 'Section 10 - Emotional wellbeing',
-          href: `/referral/${this.referralId}/emotional-wellbeing/#section-10-emotional-wellbeing`,
+          href: `/referral/${this.referral.id}/emotional-wellbeing/#section-10-emotional-wellbeing`,
           active: this.subNavValue === RisksAndNeedsPageSection.Section10EmotionalWellbeingTab,
           attributes: {
             id: 'section-10-emotional-wellbeing',
@@ -99,7 +101,7 @@ export default class RisksAndNeedsPresenter extends ReferralLayoutPresenter {
         },
         {
           text: 'Section 11 - Thinking and behaving',
-          href: `/referral/${this.referralId}/thinking-and-behaving/#section-11-thinking-and-behaving`,
+          href: `/referral/${this.referral.id}/thinking-and-behaving/#section-11-thinking-and-behaving`,
           active: this.subNavValue === RisksAndNeedsPageSection.Section11ThinkingAndBehaviourTab,
           attributes: {
             id: 'section-11-thinking-and-behaving',
@@ -107,7 +109,7 @@ export default class RisksAndNeedsPresenter extends ReferralLayoutPresenter {
         },
         {
           text: 'Section 12 - Attitudes',
-          href: `/referral/${this.referralId}/attitudes/#section-12-attitudes`,
+          href: `/referral/${this.referral.id}/attitudes/#section-12-attitudes`,
           active: this.subNavValue === RisksAndNeedsPageSection.Section12AttitudesTab,
           attributes: {
             id: 'section-12-attitudes',
@@ -115,7 +117,7 @@ export default class RisksAndNeedsPresenter extends ReferralLayoutPresenter {
         },
         {
           text: 'Section 13 - Health',
-          href: `/referral/${this.referralId}/health/#section-13-health`,
+          href: `/referral/${this.referral.id}/health/#section-13-health`,
           active: this.subNavValue === RisksAndNeedsPageSection.Section13HealthTab,
           attributes: {
             id: 'section-13-health',
@@ -123,7 +125,7 @@ export default class RisksAndNeedsPresenter extends ReferralLayoutPresenter {
         },
         {
           text: 'Section R6 - ROSH analysis',
-          href: `/referral/${this.referralId}/rosh-analysis/#section-r6-rosh-analysis`,
+          href: `/referral/${this.referral.id}/rosh-analysis/#section-r6-rosh-analysis`,
           active: this.subNavValue === RisksAndNeedsPageSection.SectionR6ROSHAnalysisTab,
           attributes: {
             id: 'section-r6-rosh-analysis',

--- a/server/risksAndNeeds/roshAnalysis/roshAnalysisPresenter.ts
+++ b/server/risksAndNeeds/roshAnalysis/roshAnalysisPresenter.ts
@@ -1,4 +1,4 @@
-import { RoshAnalysis } from '@manage-and-deliver-api'
+import { ReferralDetails, RoshAnalysis } from '@manage-and-deliver-api'
 import { InsetTextArgs } from '../../utils/govukFrontendTypes'
 import { SummaryListItem } from '../../utils/summaryList'
 import RisksAndNeedsPresenter from '../risksAndNeedsPresenter'
@@ -6,11 +6,12 @@ import RisksAndNeedsPresenter from '../risksAndNeedsPresenter'
 export default class RoshAnalysisPresenter extends RisksAndNeedsPresenter {
   constructor(
     readonly subNavValue: string,
-    readonly referralId: string,
+    readonly referral: ReferralDetails,
     readonly roshAnalysis: RoshAnalysis,
-    readonly referralStatus: string,
+    readonly isLdcUpdated: boolean | null = null,
+    readonly isCohortUpdated: boolean | null = null,
   ) {
-    super(subNavValue, referralId, referralStatus)
+    super(subNavValue, referral, isLdcUpdated, isCohortUpdated)
   }
 
   get assessmentCompletedText(): InsetTextArgs {

--- a/server/risksAndNeeds/thinkingAndBehaving/thinkingAndBehavingPresenter.ts
+++ b/server/risksAndNeeds/thinkingAndBehaving/thinkingAndBehavingPresenter.ts
@@ -1,15 +1,16 @@
-import { ThinkingAndBehaviour } from '@manage-and-deliver-api'
+import { ReferralDetails, ThinkingAndBehaviour } from '@manage-and-deliver-api'
 import RisksAndNeedsPresenter from '../risksAndNeedsPresenter'
 import { SummaryListItem } from '../../utils/summaryList'
 
 export default class ThinkingAndBehavingPresenter extends RisksAndNeedsPresenter {
   constructor(
     readonly subNavValue: string,
-    readonly referralId: string,
-    readonly referralStatus: string,
+    readonly referral: ReferralDetails,
+    readonly isLdcUpdated: boolean | null = null,
+    readonly isCohortUpdated: boolean | null = null,
     readonly thinkingAndBehaviour?: ThinkingAndBehaviour,
   ) {
-    super(subNavValue, referralId, referralStatus)
+    super(subNavValue, referral, isLdcUpdated, isCohortUpdated)
   }
 
   thinkingAndBehavingSummaryList(): SummaryListItem[] {

--- a/server/shared/referral/referralLayoutPresenter.test.ts
+++ b/server/shared/referral/referralLayoutPresenter.test.ts
@@ -5,32 +5,26 @@ import sentenceInformationFactory from '../../testutils/factories/sentenceInform
 
 describe(`getHorizontalSubNavArgs.`, () => {
   it('the correct tab will be marked as active for a referral details page', () => {
-    const referralId = randomUUID()
     const referralDetails = referralDetailsFactory.build()
     const sentenceInformation = sentenceInformationFactory.licence().build()
 
     // Used as an example to test the referral details page, as layout presenter is protected.
-    const presenter = new SentenceInformationPresenter(
-      referralDetails,
-      'sentence-information',
-      referralId,
-      sentenceInformation,
-    )
+    const presenter = new SentenceInformationPresenter(referralDetails, 'sentence-information', sentenceInformation)
 
     expect(presenter.getHorizontalSubNavArgs().items).toStrictEqual([
       {
         text: 'Referral details',
-        href: `/referral-details/${referralId}/personal-details`,
+        href: `/referral-details/${referralDetails.id}/personal-details`,
         active: true,
       },
       {
         text: 'Risks and needs',
-        href: `/referral/${referralId}/risks-and-alerts`,
+        href: `/referral/${referralDetails.id}/risks-and-alerts`,
         active: false,
       },
       {
         text: 'Programme needs identifier',
-        href: `/referral/${referralId}/programme-needs-identifier`,
+        href: `/referral/${referralDetails.id}/programme-needs-identifier`,
         active: false,
       },
       {

--- a/server/shared/referral/referralLayoutPresenter.test.ts
+++ b/server/shared/referral/referralLayoutPresenter.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'crypto'
 import SentenceInformationPresenter from '../../referralDetails/sentenceInformationPresenter'
 import referralDetailsFactory from '../../testutils/factories/referralDetailsFactory'
 import sentenceInformationFactory from '../../testutils/factories/sentenceInformationFactory'

--- a/server/shared/referral/referralLayoutPresenter.ts
+++ b/server/shared/referral/referralLayoutPresenter.ts
@@ -1,3 +1,6 @@
+import { ReferralDetails } from '@manage-and-deliver-api'
+import { firstToLowerCase, formatCohort } from '../../utils/utils'
+
 export enum HorizontalNavValues {
   referralDetailsTab = 'referralDetails',
   risksAndNeedsTab = 'risksAndNeeds',
@@ -8,9 +11,9 @@ export enum HorizontalNavValues {
 export default class ReferralLayoutPresenter {
   protected constructor(
     readonly horizontalNavValue: HorizontalNavValues,
-    readonly referralId: string,
-    readonly currentStatus: string,
+    readonly referral: ReferralDetails,
     readonly isLdcUpdated: boolean | null = null,
+    readonly isCohortUpdated: boolean | null = null,
   ) {}
 
   getButton(): { text: string; classes: string; href: string } {
@@ -22,7 +25,10 @@ export default class ReferralLayoutPresenter {
   }
 
   showButtonMenu() {
-    return this.currentStatus.toLowerCase() !== 'withdrawn' && this.currentStatus.toLowerCase() !== 'programme complete'
+    return (
+      this.referral.currentStatusDescription.toLowerCase() !== 'withdrawn' &&
+      this.referral.currentStatusDescription.toLowerCase() !== 'programme complete'
+    )
   }
 
   getButtonMenu(): {
@@ -37,18 +43,42 @@ export default class ReferralLayoutPresenter {
       items: [
         {
           text: 'Update status',
-          href: `/referral/${this.referralId}/update-status`,
+          href: `/referral/${this.referral.id}/update-status`,
         },
         {
           text: 'Change LDC status',
-          href: `/referral/${this.referralId}/update-ldc`,
+          href: `/referral/${this.referral.id}/update-ldc`,
         },
         {
           text: 'Change cohort',
-          href: `/referral/${this.referralId}/change-cohort`,
+          href: `/referral/${this.referral.id}/change-cohort`,
         },
       ],
     }
+  }
+
+  get ldcUpdatedSuccessMessageArgs() {
+    return this.isLdcUpdated
+      ? {
+          variant: 'success',
+          title: 'LDC status changed',
+          showTitleAsHeading: true,
+          dismissible: true,
+          text: `${this.referral.personName} ${firstToLowerCase(this.referral.hasLdcDisplayText)}`,
+        }
+      : {}
+  }
+
+  get cohortUpdatedSuccessMessageArgs() {
+    return this.isCohortUpdated
+      ? {
+          variant: 'success',
+          title: 'Cohort changed',
+          showTitleAsHeading: true,
+          dismissible: true,
+          text: `${this.referral.personName} is in the ${formatCohort(this.referral.cohort)} cohort`,
+        }
+      : {}
   }
 
   getSubHeaderArgs(): {
@@ -83,17 +113,17 @@ export default class ReferralLayoutPresenter {
       items: [
         {
           text: 'Referral details',
-          href: `/referral-details/${this.referralId}/personal-details`,
+          href: `/referral-details/${this.referral.id}/personal-details`,
           active: this.horizontalNavValue === HorizontalNavValues.referralDetailsTab,
         },
         {
           text: 'Risks and needs',
-          href: `/referral/${this.referralId}/risks-and-alerts`,
+          href: `/referral/${this.referral.id}/risks-and-alerts`,
           active: this.horizontalNavValue === HorizontalNavValues.risksAndNeedsTab,
         },
         {
           text: 'Programme needs identifier',
-          href: `/referral/${this.referralId}/programme-needs-identifier`,
+          href: `/referral/${this.referral.id}/programme-needs-identifier`,
           active: this.horizontalNavValue === HorizontalNavValues.programmeNeedsIdentifierTab,
         },
         {

--- a/server/updateReferralStatus/updateReferralStatusController.test.ts
+++ b/server/updateReferralStatus/updateReferralStatusController.test.ts
@@ -4,7 +4,6 @@ import { randomUUID } from 'crypto'
 import { ReferralDetails } from '@manage-and-deliver-api'
 import { SessionData } from 'express-session'
 import referralStatusFormDataFactory from '../testutils/factories/referralStatusFormDataFactory'
-import { appWithAllRoutes } from '../routes/testutils/appSetup'
 import AccreditedProgrammesManageAndDeliverService from '../services/accreditedProgrammesManageAndDeliverService'
 import referralDetailsFactory from '../testutils/factories/referralDetailsFactory'
 import TestUtils from '../testutils/testUtils'
@@ -64,7 +63,6 @@ describe('update-status', () => {
 
   describe(`POST /referral/:referralDetails.id/update-status`, () => {
     it('posts to the update status endpoint and redirects successfully to the correct page', async () => {
-      console.log(JSON.stringify(referralDetails, null, 2))
       return request(app)
         .post(`/referral/${referralDetails.id}/update-status`)
         .type('form')

--- a/server/updateReferralStatus/updateReferralStatusController.test.ts
+++ b/server/updateReferralStatus/updateReferralStatusController.test.ts
@@ -2,10 +2,12 @@ import { Express } from 'express'
 import request from 'supertest'
 import { randomUUID } from 'crypto'
 import { ReferralDetails } from '@manage-and-deliver-api'
+import { SessionData } from 'express-session'
 import referralStatusFormDataFactory from '../testutils/factories/referralStatusFormDataFactory'
 import { appWithAllRoutes } from '../routes/testutils/appSetup'
 import AccreditedProgrammesManageAndDeliverService from '../services/accreditedProgrammesManageAndDeliverService'
 import referralDetailsFactory from '../testutils/factories/referralDetailsFactory'
+import TestUtils from '../testutils/testUtils'
 
 jest.mock('../services/accreditedProgrammesManageAndDeliverService')
 jest.mock('../data/hmppsAuthClient')
@@ -19,23 +21,21 @@ let app: Express
 
 const referralDetails: ReferralDetails = referralDetailsFactory.build()
 const statusDetails = referralStatusFormDataFactory.build()
-const referralId = randomUUID()
 
 afterEach(() => {
   jest.resetAllMocks()
 })
 beforeEach(() => {
-  app = appWithAllRoutes({
-    services: {
-      accreditedProgrammesManageAndDeliverService,
-    },
-  })
+  const sessionData: Partial<SessionData> = {
+    originPage: '/referral-details/1/personal-details',
+  }
+  app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
   accreditedProgrammesManageAndDeliverService.getReferralDetails.mockResolvedValue(referralDetails)
   accreditedProgrammesManageAndDeliverService.getStatusDetails.mockResolvedValue(statusDetails)
 })
 
 describe('update-status', () => {
-  describe(`GET /referral/:referralId/update-status`, () => {
+  describe(`GET /referral/:referralDetails.id/update-status`, () => {
     it('loads the update status page', async () => {
       return request(app)
         .get(`/referral/${randomUUID()}/update-status`)
@@ -49,20 +49,24 @@ describe('update-status', () => {
     })
 
     it('calls the service with correct parameters', async () => {
-      await request(app).get(`/referral/${referralId}/update-status`).expect(200)
-      expect(accreditedProgrammesManageAndDeliverService.getStatusDetails).toHaveBeenCalledWith(referralId, 'user1')
+      await request(app).get(`/referral/${referralDetails.id}/update-status`).expect(200)
+      expect(accreditedProgrammesManageAndDeliverService.getStatusDetails).toHaveBeenCalledWith(
+        referralDetails.id,
+        'user1',
+      )
     })
 
     it('handles service errors gracefully', async () => {
       accreditedProgrammesManageAndDeliverService.getStatusDetails.mockRejectedValue(new Error('Service unavailable'))
-      return request(app).get(`/referral/${referralId}/update-status`).expect(500)
+      return request(app).get(`/referral/${referralDetails.id}/update-status`).expect(500)
     })
   })
 
-  describe(`POST /referral/:referralId/update-status`, () => {
+  describe(`POST /referral/:referralDetails.id/update-status`, () => {
     it('posts to the update status endpoint and redirects successfully to the correct page', async () => {
+      console.log(JSON.stringify(referralDetails, null, 2))
       return request(app)
-        .post(`/referral/${referralId}/update-status`)
+        .post(`/referral/${referralDetails.id}/update-status`)
         .type('form')
         .send({
           'updated-status': 'afc0b94c-b983-4a68-a109-0be29a7d3b2f',
@@ -71,13 +75,13 @@ describe('update-status', () => {
         .expect(302)
         .expect(res => {
           expect(res.text).toContain(
-            `Redirecting to /referral-details/${referralId}/personal-details?statusUpdated=true`,
+            `Redirecting to /referral-details/${referralDetails.id}/personal-details?statusUpdated=true`,
           )
         })
     })
     it('handles form errors correctly and displays the appropriate error message', async () => {
       return request(app)
-        .post(`/referral/${referralId}/update-status`)
+        .post(`/referral/${referralDetails.id}/update-status`)
         .type('form')
         .send({
           'updated-status': undefined,

--- a/server/updateReferralStatus/updateReferralStatusController.ts
+++ b/server/updateReferralStatus/updateReferralStatusController.ts
@@ -33,7 +33,7 @@ export default class UpdateReferralStatusController {
         userInputData = req.body
       } else {
         await this.accreditedProgrammesManageAndDeliverService.updateStatus(username, referralId, data.paramsForUpdate)
-        return res.redirect(`/referral-details/${referralId}/personal-details?statusUpdated=true`)
+        return res.redirect(`${req.session.originPage}?statusUpdated=true`)
       }
     }
 
@@ -45,6 +45,7 @@ export default class UpdateReferralStatusController {
       req.session.originPage,
     )
     const view = new UpdateReferralStatusView(presenter)
+    req.session.originPage = req.path
     return ControllerUtils.renderWithLayout(res, view, referralDetails)
   }
 }

--- a/server/views/pni/pni.njk
+++ b/server/views/pni/pni.njk
@@ -4,6 +4,7 @@
 {% from "moj/components/page-header-actions/macro.njk" import mojPageHeaderActions %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "components/rosh-widget/macro.njk" import roshWidget %}
+{%- from "moj/components/alert/macro.njk" import mojAlert -%}
 
 {% set pageTitle = applicationName + " - Home" %}
 {% set mainClasses = "app-container govuk-body" %}
@@ -20,10 +21,10 @@
             </div>
 
             <div class="govuk-grid-column-three-quarters">
-              {% if isCohortUpdated %}
+              {% if presenter.isCohortUpdated %}
                 {{ mojAlert(presenter.cohortUpdatedSuccessMessageArgs) }}
               {% endif %}
-              {% if isLdcUpdated %}
+              {% if presenter.isLdcUpdated %}
                 {{ mojAlert(presenter.ldcUpdatedSuccessMessageArgs) }}
               {% endif %}
               <h2 class="govuk-heading-m">Programme needs identifier</h2>

--- a/server/views/referralDetails/referralDetails.njk
+++ b/server/views/referralDetails/referralDetails.njk
@@ -20,10 +20,10 @@
             </div>
 
             <div class="govuk-grid-column-three-quarters">
-              {% if isCohortUpdated %}
+              {% if presenter.isCohortUpdated %}
                 {{ mojAlert(presenter.cohortUpdatedSuccessMessageArgs) }}
               {% endif %}
-              {% if isLdcUpdated %}
+              {% if presenter.isLdcUpdated %}
                 {{ mojAlert(presenter.ldcUpdatedSuccessMessageArgs) }}
               {% endif %}
               <h2 class="govuk-heading-m">Referral summary</h2>

--- a/server/views/risksAndNeeds/risksAndNeeds.njk
+++ b/server/views/risksAndNeeds/risksAndNeeds.njk
@@ -4,6 +4,7 @@
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {%- from "moj/components/side-navigation/macro.njk" import mojSideNavigation -%}
 {% from "moj/components/page-header-actions/macro.njk" import mojPageHeaderActions %}
+{%- from "moj/components/alert/macro.njk" import mojAlert -%}
 
 {% set pageTitle = applicationName + " - Home" %}
 {% set mainClasses = "app-container govuk-body" %}
@@ -20,10 +21,10 @@
             </div>
 
             <div class="govuk-grid-column-three-quarters">
-              {% if isCohortUpdated %}
+              {% if presenter.isCohortUpdated %}
                 {{ mojAlert(presenter.cohortUpdatedSuccessMessageArgs) }}
               {% endif %}
-              {% if isLdcUpdated %}
+              {% if presenter.isLdcUpdated %}
                 {{ mojAlert(presenter.ldcUpdatedSuccessMessageArgs) }}
               {% endif %}
               <h2 class="govuk-heading-m">Risks and needs</h2>


### PR DESCRIPTION
LDC and Cohort Success messages are now managed by the parent presenter
LDC and Cohort update values still need to be passed through to the parent presenter
Removed redundant passing of Referral IDs where we are also passing the referral object to reduce number of params being passed around
Redirect after successful LDC or Cohort update back to the page the user was originally on instead of the personal details page every time