### PR TITLE
Apg 1992/session notes character count

### DIFF
--- a/server/attendance/attendanceController.test.ts
+++ b/server/attendance/attendanceController.test.ts
@@ -92,6 +92,34 @@ describe('showRecordAttendancePage', () => {
           expect(res.text).toContain('value="AFTC" checked')
         })
     })
+
+    it('redirects directly to the selected referral notes when referralId query is present', async () => {
+      sessionData = {
+        editSessionAttendance: {
+          referralIds: ['referral1', 'referral2'],
+          attendees: [
+            { referralId: 'referral1', outcomeCode: 'ATTC' },
+            { referralId: 'referral2', outcomeCode: 'ATTC' },
+          ],
+        },
+      }
+
+      app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
+
+      const bffData = recordSessionAttendanceFactory.build({ sessionTitle: 'Getting started 1' })
+      accreditedProgrammesManageAndDeliverService.getRecordAttendanceBffData.mockResolvedValue(bffData)
+
+      await request(app)
+        .get('/group/111/session/6789/record-attendance?referralId=referral2')
+        .expect(302)
+        .expect('Location', '/group/111/session/6789/referral/referral2/getting-started-1-session-notes')
+
+      expect(accreditedProgrammesManageAndDeliverService.getRecordAttendanceBffData).toHaveBeenCalledWith(
+        'user1',
+        '6789',
+        ['referral2'],
+      )
+    })
   })
 
   describe('POST /group/:groupId/session/:sessionId/record-attendance', () => {
@@ -521,6 +549,50 @@ describe('showRecordAttendancePage', () => {
       )
     })
 
+    it('stages current attendee from BFF and submits successfully when journey starts on notes page', async () => {
+      sessionData = {
+        editSessionAttendance: {
+          source: 'session-notes',
+          referralIds: ['referral1'],
+          attendees: [],
+        },
+      }
+
+      app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
+
+      const bffData = recordSessionAttendanceFactory.build({ sessionTitle: 'Understanding myself' })
+      bffData.people = [
+        {
+          ...bffData.people[0],
+          referralId: 'referral1',
+          name: 'Hannah Schinner',
+          attendance: { text: 'Attended', code: 'ATTC' },
+        },
+      ]
+
+      accreditedProgrammesManageAndDeliverService.getRecordAttendanceBffData.mockResolvedValue(bffData)
+      accreditedProgrammesManageAndDeliverService.createSessionAttendance.mockResolvedValue({
+        attendees: [{ referralId: 'referral1', outcomeCode: 'ATTC', sessionNotes: 'Some notes' }],
+        responseMessage: 'Attendance updated',
+      })
+
+      await request(app)
+        .post('/group/111/session/6789/referral/referral1/understanding-myself-session-notes')
+        .type('form')
+        .send({
+          'record-session-attendance-notes': 'Some notes',
+        })
+        .expect(302)
+
+      expect(accreditedProgrammesManageAndDeliverService.createSessionAttendance).toHaveBeenCalledWith(
+        'user1',
+        '6789',
+        {
+          attendees: [{ referralId: 'referral1', outcomeCode: 'ATTC', sessionNotes: 'Some notes' }],
+        },
+      )
+    })
+
     it('redirects back to edit session with a success message on the last referral when journey started from edit session', async () => {
       sessionData = {
         editSessionAttendance: {
@@ -550,6 +622,52 @@ describe('showRecordAttendancePage', () => {
         .expect(res => {
           expect(res.text).toContain(
             'Redirecting to /group/111/session/6789/edit-session?message=Attendance+recorded+for+Alice+Brown.',
+          )
+        })
+    })
+
+    it('redirects back to edit session with all attendee names when journey started from edit session', async () => {
+      sessionData = {
+        editSessionAttendance: {
+          source: 'edit-session',
+          referralIds: ['referral1', 'referral2', 'referral3'],
+          attendees: [
+            { referralId: 'referral1', outcomeCode: 'ATTC', sessionNotes: '' },
+            { referralId: 'referral2', outcomeCode: 'ATTC', sessionNotes: '' },
+            { referralId: 'referral3', outcomeCode: 'ATTC', sessionNotes: '' },
+          ],
+        },
+      }
+
+      app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
+
+      const bffData = recordSessionAttendanceFactory.build({ sessionTitle: 'Getting started 1' })
+      bffData.people = [
+        { ...bffData.people[0], referralId: 'referral1', name: 'Sham Booth' },
+        { ...bffData.people[1], referralId: 'referral2', name: 'Adrian Poole' },
+        { ...bffData.people[0], referralId: 'referral3', name: 'Hannah Schinner' },
+      ]
+
+      accreditedProgrammesManageAndDeliverService.getRecordAttendanceBffData.mockResolvedValue(bffData)
+      accreditedProgrammesManageAndDeliverService.createSessionAttendance.mockResolvedValue({
+        attendees: [
+          { referralId: 'referral1', outcomeCode: 'ATTC', sessionNotes: '' },
+          { referralId: 'referral2', outcomeCode: 'ATTC', sessionNotes: '' },
+          { referralId: 'referral3', outcomeCode: 'ATTC', sessionNotes: '' },
+        ],
+        responseMessage: 'Attendance updated',
+      })
+
+      await request(app)
+        .post('/group/111/session/6789/referral/referral3/getting-started-1-session-notes')
+        .type('form')
+        .send({
+          'record-session-attendance-notes': 'Some notes',
+        })
+        .expect(302)
+        .expect(res => {
+          expect(res.text).toContain(
+            'Redirecting to /group/111/session/6789/edit-session?message=Attendance+recorded+for+Sham+Booth%2C+Adrian+Poole+and+Hannah+Schinner.',
           )
         })
     })

--- a/server/attendance/attendanceController.ts
+++ b/server/attendance/attendanceController.ts
@@ -146,12 +146,12 @@ export default class AttendanceController extends BaseController {
     const isLastReferral = currentReferralIndex === referralIds.length - 1
     let currentAttendee = attendees.find(attendee => attendee.referralId === referralId)
     const referralPerson = recordAttendanceBffData.people.find(person => person.referralId === referralId)
-    const referralAttendanceCode = referralPerson?.attendance?.code
+    const referralAttendanceCode = this.resolveOutcomeCodeFromPerson(referralPerson)
 
-    if (!currentAttendee && ['ATTC', 'AFTC', 'UAAB'].includes(referralAttendanceCode || '')) {
+    if (!currentAttendee && referralAttendanceCode) {
       currentAttendee = {
         referralId,
-        outcomeCode: referralAttendanceCode as SessionAttendance['attendees'][number]['outcomeCode'],
+        outcomeCode: referralAttendanceCode,
         sessionNotes: referralPerson.sessionNotes,
       }
       attendees.push(currentAttendee)
@@ -307,6 +307,24 @@ export default class AttendanceController extends BaseController {
 
   private notesPageUri(groupId: string, sessionId: string, referralId: string, groupTitle: string): string {
     return `/group/${groupId}/session/${sessionId}/referral/${referralId}/${groupTitle}-session-notes`
+  }
+
+  private resolveOutcomeCodeFromPerson(
+    person: RecordSessionAttendance['people'][number] | undefined,
+  ): SessionAttendance['attendees'][number]['outcomeCode'] | null {
+    const code = person?.attendance?.code
+
+    if (typeof code !== 'string') {
+      return null
+    }
+
+    const validCodes = new Set((person?.options || []).map(option => option.value))
+
+    if (!validCodes.has(code)) {
+      return null
+    }
+
+    return code as SessionAttendance['attendees'][number]['outcomeCode']
   }
 
   private formatNameList(names: string[]): string {

--- a/server/attendance/attendanceController.ts
+++ b/server/attendance/attendanceController.ts
@@ -24,7 +24,17 @@ export default class AttendanceController extends BaseController {
   async showRecordAttendancePage(req: Request, res: Response): Promise<void> {
     const { username } = req.user
     const { groupId, sessionId } = req.params
-    const referralIds = this.referralIds(req)
+    const referralIdFromQuery = typeof req.query.referralId === 'string' ? req.query.referralId : null
+
+    let referralIds = this.referralIds(req)
+    if (referralIdFromQuery) {
+      referralIds = [referralIdFromQuery]
+      req.session.editSessionAttendance = {
+        ...req.session.editSessionAttendance,
+        attendees: req.session.editSessionAttendance?.attendees ?? [],
+        referralIds,
+      }
+    }
 
     if (!referralIds.length) {
       return res.redirect(`/group/${groupId}/session/${sessionId}/edit-session`)
@@ -39,6 +49,11 @@ export default class AttendanceController extends BaseController {
       sessionId,
       referralIds,
     )
+
+    if (req.method === 'GET' && referralIdFromQuery) {
+      const sessionTitle = convertToUrlFriendlyKebabCase(recordAttendanceBffData.sessionTitle)
+      return res.redirect(this.notesPageUri(groupId, sessionId, referralIdFromQuery, sessionTitle))
+    }
 
     const recordAttendanceDataWithSessionSelections: RecordSessionAttendance = {
       ...recordAttendanceBffData,
@@ -129,8 +144,20 @@ export default class AttendanceController extends BaseController {
     }
 
     const isLastReferral = currentReferralIndex === referralIds.length - 1
-    const currentAttendee = attendees.find(attendee => attendee.referralId === referralId)
+    let currentAttendee = attendees.find(attendee => attendee.referralId === referralId)
     const referralPerson = recordAttendanceBffData.people.find(person => person.referralId === referralId)
+    const referralAttendanceCode = referralPerson?.attendance?.code
+
+    if (!currentAttendee && ['ATTC', 'AFTC', 'UAAB'].includes(referralAttendanceCode || '')) {
+      currentAttendee = {
+        referralId,
+        outcomeCode: referralAttendanceCode as SessionAttendance['attendees'][number]['outcomeCode'],
+        sessionNotes: referralPerson.sessionNotes,
+      }
+      attendees.push(currentAttendee)
+      req.session.editSessionAttendance.attendees = attendees
+    }
+
     const selectedAttendanceCode = currentAttendee?.outcomeCode
 
     const backLinkUri =
@@ -169,9 +196,15 @@ export default class AttendanceController extends BaseController {
       }
 
       if (isLastReferral) {
+        const attendeesForSubmission = this.normaliseAttendeesForSubmission(attendees)
+
+        if (!attendeesForSubmission.length) {
+          return res.redirect(`/group/${groupId}/session/${sessionId}/edit-session`)
+        }
+
         const createSessionAttendanceResponse =
           await this.accreditedProgrammesManageAndDeliverService.createSessionAttendance(username, sessionId, {
-            attendees: this.normaliseAttendeesForSubmission(attendees),
+            attendees: attendeesForSubmission,
           })
 
         const attendeeReferralIds = createSessionAttendanceResponse.attendees.map(attendee => attendee.referralId)
@@ -179,13 +212,21 @@ export default class AttendanceController extends BaseController {
 
         const currentPersonName =
           recordAttendanceBffData.people.find(person => person.referralId === referralId)?.name || ''
+        const recordedReferralIds = attendeeReferralIds.length ? attendeeReferralIds : referralIds
+        const recordedNames = recordedReferralIds
+          .map(
+            recordedReferralId =>
+              recordAttendanceBffData.people.find(person => person.referralId === recordedReferralId)?.name,
+          )
+          .filter((name): name is string => Boolean(name))
         const journeySource = req.session.editSessionAttendance?.source
 
         if (journeySource === 'edit-session') {
           delete req.session.editSessionAttendance
 
+          const personNames = recordedNames.length ? recordedNames : [currentPersonName]
           const redirectQuery = new URLSearchParams({
-            message: `Attendance recorded for ${currentPersonName}.`,
+            message: `Attendance recorded for ${this.formatNameList(personNames)}.`,
           })
 
           return res.redirect(`/group/${groupId}/session/${sessionId}/edit-session?${redirectQuery}`)
@@ -266,5 +307,17 @@ export default class AttendanceController extends BaseController {
 
   private notesPageUri(groupId: string, sessionId: string, referralId: string, groupTitle: string): string {
     return `/group/${groupId}/session/${sessionId}/referral/${referralId}/${groupTitle}-session-notes`
+  }
+
+  private formatNameList(names: string[]): string {
+    if (names.length <= 1) {
+      return names[0] || 'selected attendees'
+    }
+
+    if (names.length === 2) {
+      return `${names[0]} and ${names[1]}`
+    }
+
+    return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`
   }
 }

--- a/server/attendance/attendanceNotes/attendanceSessionNotesForm.test.ts
+++ b/server/attendance/attendanceNotes/attendanceSessionNotesForm.test.ts
@@ -40,6 +40,20 @@ describe('AttendanceSessionNotesForm', () => {
     })
   })
 
+  it('accepts CRLF content that is within the 10000 character limit after normalising line endings', async () => {
+    const req = buildRequest({
+      'record-session-attendance-notes': 'a\r\n'.repeat(5000),
+    })
+
+    const result = await new AttendanceSessionNotesForm(req).sessionNotesData()
+
+    expect(result.error).toBeNull()
+    expect(result.paramsForUpdate).toEqual({
+      sessionNotes: 'a\r\n'.repeat(5000),
+      isSkipAndAddLater: false,
+    })
+  })
+
   it('skips validation when action is skip-and-add-later', async () => {
     const req = buildRequest({
       action: 'skip-and-add-later',

--- a/server/attendance/attendanceNotes/attendanceSessionNotesForm.ts
+++ b/server/attendance/attendanceNotes/attendanceSessionNotesForm.ts
@@ -57,7 +57,7 @@ export default class AttendanceSessionNotesForm {
       body('record-session-attendance-notes')
         .custom((value: unknown) => {
           const notes = typeof value === 'string' ? value : ''
-          return notes.length <= 10000
+          return notes.replace(/\r\n/g, '\n').length <= 10000
         })
         .withMessage(errorMessages.recordAttendance.sessionNotesTooLong),
     ]

--- a/server/createGroup/createGroupController.test.ts
+++ b/server/createGroup/createGroupController.test.ts
@@ -120,6 +120,19 @@ describe('Create Group Controller', () => {
         })
     })
 
+    it('redirects to start date page when group code lookup returns 404', async () => {
+      accreditedProgrammesManageAndDeliverService.getGroupByCodeInRegion.mockRejectedValue({ status: 404 })
+
+      return request(app)
+        .post('/group/create-a-group/create-group-code')
+        .type('form')
+        .send({ 'create-group-code': 'ABC123' })
+        .expect(302)
+        .expect(res => {
+          expect(res.text).toContain('Redirecting to /group/create-a-group/group-start-date')
+        })
+    })
+
     it('returns with errors if group code is missing', async () => {
       return request(app)
         .post('/group/create-a-group/create-group-code')

--- a/server/createGroup/createGroupController.ts
+++ b/server/createGroup/createGroupController.ts
@@ -61,7 +61,7 @@ export default class CreateGroupController extends BaseController {
             username,
             req.body['create-group-code'],
           )
-          existingGroupCode = existingGroup.code
+          existingGroupCode = existingGroup?.code || ''
         } catch (error) {
           if ((error as { status?: number }).status !== 404) {
             throw error

--- a/server/createGroup/createGroupController.ts
+++ b/server/createGroup/createGroupController.ts
@@ -49,11 +49,27 @@ export default class CreateGroupController extends BaseController {
   }
 
   async showCreateGroupCode(req: Request, res: Response): Promise<void> {
+    const { username } = req.user
     const { createGroupFormData } = req.session
     let userInputData = null
     let formError: FormValidationError | null = null
     if (req.method === 'POST') {
-      const data = await new CreateOrEditGroupForm(req, '').createGroupCodeData()
+      let existingGroupCode = ''
+      if (req.body['create-group-code']) {
+        try {
+          const existingGroup = await this.accreditedProgrammesManageAndDeliverService.getGroupByCodeInRegion(
+            username,
+            req.body['create-group-code'],
+          )
+          existingGroupCode = existingGroup.code
+        } catch (error) {
+          if ((error as { status?: number }).status !== 404) {
+            throw error
+          }
+        }
+      }
+
+      const data = await new CreateOrEditGroupForm(req, existingGroupCode).createGroupCodeData()
       if (data.error) {
         res.status(400)
         formError = data.error

--- a/server/sessionNotes/sessionNotesController.test.ts
+++ b/server/sessionNotes/sessionNotesController.test.ts
@@ -415,7 +415,7 @@ describe('SessionNotesController', () => {
           expect(res.text).toContain('<p class="govuk-body-m">Participant engaged well.</p>')
           expect(res.text).not.toContain('id="sessionNotes"')
           expect(res.text).toContain(
-            '/group/d193bf89-c98b-4e92-b842-3c1b3e5f5e4a/session/a1b2c3d4-e5f6-7890-abcd-ef1234567890/record-attendance',
+            '/group/d193bf89-c98b-4e92-b842-3c1b3e5f5e4a/session/a1b2c3d4-e5f6-7890-abcd-ef1234567890/record-attendance?referralId=referral-123',
           )
         })
     })
@@ -465,6 +465,77 @@ describe('SessionNotesController', () => {
         .expect(res => {
           expect(res.text).toContain('Alex River')
         })
+
+      expect(accreditedProgrammesManageAndDeliverService.getRecordAttendanceBffData).toHaveBeenCalledWith(
+        'user1',
+        '6789',
+        ['referral-123'],
+      )
+    })
+
+    it('scopes selection to clicked referral when opened from edit session notes', async () => {
+      const sessionData: Partial<SessionData> = {
+        editSessionAttendance: {
+          referralIds: ['referral-999'],
+          attendees: [{ referralId: 'referral-999', outcomeCode: 'ATTC', sessionNotes: '' }],
+        },
+      }
+
+      app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
+
+      accreditedProgrammesManageAndDeliverService.getSessionNotes.mockResolvedValue({
+        pageTitle: 'Alex River: Getting started 1 Introduction to Building Choices session notes',
+        moduleName: 'Getting started',
+        sessionName: 'Introduction to Building Choices',
+        sessionNumber: 1,
+        lastUpdatedBy: 'John Smith',
+        lastUpdatedDate: '19 March 2026',
+        groupId: 'd193bf89-c98b-4e92-b842-3c1b3e5f5e4a',
+        sessionId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+        sessionDate: '21 July 2025',
+        sessionAttendance: 'Attended, failed to comply',
+        sessionNotes: 'Participant engaged well.',
+      })
+
+      accreditedProgrammesManageAndDeliverService.getRecordAttendanceBffData.mockResolvedValue({
+        sessionTitle: 'Getting started 1',
+        groupRegionName: 'North East',
+        people: [
+          {
+            referralId: 'referral-123',
+            name: 'Alex River',
+            crn: 'X12345',
+            attendance: {
+              code: 'AFTC',
+              text: 'Attended, failed to comply',
+            },
+            sessionNotes: 'Participant engaged well.',
+            options: [],
+          },
+          {
+            referralId: 'referral-999',
+            name: 'Taylor Smith',
+            crn: 'X67890',
+            attendance: {
+              code: 'ATTC',
+              text: 'Attended',
+            },
+            sessionNotes: '',
+            options: [],
+          },
+        ],
+      })
+
+      const agent = request.agent(app)
+
+      await agent
+        .get('/group/111/session/6789/getting-started-1/session-notes?referralId=referral-123&source=edit-session')
+        .expect(200)
+
+      await agent
+        .get('/group/111/session/6789/record-attendance?referralId=referral-123')
+        .expect(302)
+        .expect('Location', '/group/111/session/6789/referral/referral-123/getting-started-1-session-notes')
 
       expect(accreditedProgrammesManageAndDeliverService.getRecordAttendanceBffData).toHaveBeenCalledWith(
         'user1',

--- a/server/sessionNotes/sessionNotesController.ts
+++ b/server/sessionNotes/sessionNotesController.ts
@@ -166,7 +166,7 @@ export default class SessionNotesController extends BaseController {
       ...existingSelection,
       source: 'session-notes',
       attendees: existingSelection?.attendees ?? [],
-      referralIds: existingReferralIds.length ? existingReferralIds : [referralId],
+      referralIds: [referralId],
     }
   }
 

--- a/server/sessionNotes/sessionNotesController.ts
+++ b/server/sessionNotes/sessionNotesController.ts
@@ -154,14 +154,6 @@ export default class SessionNotesController extends BaseController {
   private seedAttendanceSelection(req: Request, referralId: string): void {
     const existingSelection = req.session.editSessionAttendance
 
-    let existingReferralIds: string[] = []
-
-    if (Array.isArray(existingSelection?.referralIds)) {
-      existingReferralIds = existingSelection.referralIds
-    } else if (existingSelection?.referralIds) {
-      existingReferralIds = [existingSelection.referralIds]
-    }
-
     req.session.editSessionAttendance = {
       ...existingSelection,
       source: 'session-notes',

--- a/server/sessionNotes/sessionNotesForm.test.ts
+++ b/server/sessionNotes/sessionNotesForm.test.ts
@@ -45,6 +45,13 @@ describe('SessionNotesForm', () => {
     })
   })
 
+  it('treats CRLF line endings as a single character for length validation', () => {
+    const form = new SessionNotesForm()
+    const notes = 'a\r\n'.repeat(5000)
+
+    expect(form.validateSessionNotes(notes)).toBeNull()
+  })
+
   it('validates empty session notes', () => {
     const form = new SessionNotesForm()
 

--- a/server/sessionNotes/sessionNotesForm.ts
+++ b/server/sessionNotes/sessionNotesForm.ts
@@ -3,7 +3,7 @@ import errorMessages from '../utils/errorMessages'
 
 export default class SessionNotesForm {
   validateSessionNotes(notes: string): FormValidationError | null {
-    if (notes.length <= 10000) {
+    if (SessionNotesForm.normalisedLength(notes) <= 10000) {
       return null
     }
 
@@ -16,5 +16,9 @@ export default class SessionNotesForm {
         },
       ],
     }
+  }
+
+  private static normalisedLength(notes: string): number {
+    return notes.replace(/\r\n/g, '\n').length
   }
 }

--- a/server/sessionNotes/sessionNotesPresenter.test.ts
+++ b/server/sessionNotes/sessionNotesPresenter.test.ts
@@ -207,7 +207,7 @@ describe('SessionNotesPresenter', () => {
         {
           text: 'Update attendance and notes',
           classes: 'govuk-button--primary',
-          href: '/group/b2c3d4e5-f6a7-8901-bcde-f23456789012/session/c3d4e5f6-a7b8-9012-cdef-345678901234/record-attendance',
+          href: '/group/b2c3d4e5-f6a7-8901-bcde-f23456789012/session/c3d4e5f6-a7b8-9012-cdef-345678901234/record-attendance?referralId=referral-123',
         },
       ],
     })

--- a/server/sessionNotes/sessionNotesPresenter.ts
+++ b/server/sessionNotes/sessionNotesPresenter.ts
@@ -98,7 +98,9 @@ export default class SessionNotesPresenter {
   }
 
   get recordAttendanceUrl(): string {
-    return `/group/${this.data.groupId}/session/${this.data.sessionId}/record-attendance`
+    const query = new URLSearchParams({ referralId: this.data.referralId })
+
+    return `/group/${this.data.groupId}/session/${this.data.sessionId}/record-attendance?${query.toString()}`
   }
 
   get pageHeaderActionsArgs() {


### PR DESCRIPTION
1. I noticed a few issues in the 'Session notes' journey that I have addressed in this PR.

For example on this page: https://accredited-programmes-manage-and-deliver-dev.hmpps.service.justice.gov.uk/group/466ba4c3-2dbd-4cac-bba1-63127af52a5c/session/700a5f53-d89a-483b-9b09-4687252dcf26/getting-started-1-introduction-to-building-choices/session-notes?referralId=0814d3aa-dce9-41e6-971f-d19f1efa4ee1&source=edit-session - if I click the 'update attendance and notes' button, it is going to an a different person's attendance. Most of the others dont seem to do this.


2. There is an issue with the character count in the text box. You will see in the image, there is still one character under the 10 thousand characters, but it still shows an error on submit.

<img width="1262" height="1171" alt="Screenshot 2026-04-10 at 10 16 31" src="https://github.com/user-attachments/assets/f8ac3a73-82cb-4bfa-b50e-847e8512b827" />

3. The success message was only showing one person's name, even when several attendances had been updated. This had worked previously.