### PR TITLE
Add SVRP to the OGRS4 version of the risks and needs page

### DIFF
--- a/server/risksAndNeeds/risksAndAlerts/risksAndAlertsOgrs4View.ts
+++ b/server/risksAndNeeds/risksAndAlerts/risksAndAlertsOgrs4View.ts
@@ -115,6 +115,18 @@ export default class RisksAndAlertsOgrs4View {
     }
   }
 
+  get seriousViolentReoffendingPredictor() {
+    return {
+      level: this.presenter.levelOrUnknown(this.presenter.risks.ogrS4Risks.seriousViolentReoffendingBand),
+      score: this.presenter.risks.ogrS4Risks.seriousViolentReoffendingScore,
+      type: 'Serious violent reoffending predictor',
+      staticOrDynamic: this.presenter.risks.ogrS4Risks.seriousViolentReoffendingScoreType
+        ? this.presenter.risks.ogrS4Risks.seriousViolentReoffendingScoreType.toUpperCase()
+        : null,
+      completedDate: this.presenter.risks.lastUpdated,
+    }
+  }
+
   get directContactSexualReoffendingPredictor() {
     return {
       level: this.presenter.levelOrUnknown(this.presenter.risks.ogrS4Risks.directContactSexualReoffendingBand),
@@ -195,6 +207,7 @@ export default class RisksAndAlertsOgrs4View {
         riskTowardsPartnerBox: this.riskTowardsPartnerBox,
         riskTowardsOthersBox: this.riskTowardsOthersBox,
         combinedSeriousReoffendingPredictor: this.combinedSeriousReoffendingPredictor,
+        seriousViolentReoffendingPredictor: this.seriousViolentReoffendingPredictor,
         directContactSexualReoffendingPredictor: this.directContactSexualReoffendingPredictor,
         imagesAndIndirectContactSexualReoffendingPredictor: this.imagesAndIndirectContactSexualReoffendingPredictor,
         roshRiskSummary: this.roshRiskSummary,

--- a/server/views/risksAndNeeds/risksAndAlertsOgrs4.njk
+++ b/server/views/risksAndNeeds/risksAndAlertsOgrs4.njk
@@ -31,6 +31,8 @@
 
     <h2 class="govuk-heading-m">Combined serious reoffending predictor</h2>
     {{ expandedPredictorBadge(combinedSeriousReoffendingPredictor, true, false) }}
+    <p>The combined serious reoffending predictor combines 3 scores:</p>
+    {{ expandedPredictorBadge(seriousViolentReoffendingPredictor, true, false) }}
     {{ expandedPredictorBadge(directContactSexualReoffendingPredictor, true, false) }}
     {{ expandedPredictorBadge(imagesAndIndirectContactSexualReoffendingPredictor, true, false) }}
     {{ roshWidget(roshRiskSummary) }}

--- a/wiremock_mappings/arnsApi.json
+++ b/wiremock_mappings/arnsApi.json
@@ -48,23 +48,32 @@
           "output": {
             "allReoffendingPredictor": {
               "staticOrDynamic": "STATIC",
-              "score": 76.2,
-              "band": "HIGH"
+              "score": 12.34,
+              "band": "LOW"
             },
             "violentReoffendingPredictor": {
-              "staticOrDynamic": "STATIC",
-              "score": 46.73,
+              "staticOrDynamic": "DYNAMIC",
+              "score": 34.56,
               "band": "MEDIUM"
             },
             "seriousViolentReoffendingPredictor": {
               "staticOrDynamic": "STATIC",
-              "score": 5.48,
+              "score": 4.56,
               "band": "HIGH"
             },
-            "directContactSexualReoffendingPredictor": {},
-            "indirectImageContactSexualReoffendingPredictor": {},
+            "directContactSexualReoffendingPredictor": {
+              "score": 83.1,
+              "band": "VERY_HIGH"
+            },
+            "indirectImageContactSexualReoffendingPredictor": {
+              "score": 0.12,
+              "band": "LOW"
+            },
             "combinedSeriousReoffendingPredictor": {
-              "algorithmVersion": "6"
+              "algorithmVersion": 6,
+              "staticOrDynamic": "DYNAMIC",
+              "score": 0.89,
+              "band": "LOW"
             }
           }
         }


### PR DESCRIPTION
Add Serious violent reoffending predictor to the OGRS4 version of the risks and needs page

<img width="3456" height="7795" alt="image" src="https://github.com/user-attachments/assets/f7efffe4-3879-4724-af52-b975d0749c51" />
