### PR TITLE
Beta banner added to all pages

### DIFF
--- a/server/views/partials/betaBanner.njk
+++ b/server/views/partials/betaBanner.njk
@@ -1,0 +1,8 @@
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+
+{{ govukPhaseBanner({
+  tag: {
+    text: "Beta"
+  },
+  html: 'This is a new service – your <a class="govuk-link" href="https://www.smartsurvey.co.uk/s/QIOAIE/">feedback</a> will help us to improve it.'
+}) }}

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -10,6 +10,7 @@
 
 {% block header %}
   {% include "./header.njk" %}
+  {% include "./betaBanner.njk" %}
   {{ customPrimaryNavigation(primaryNavigationArgs) }}
 
   {% if serviceUserBannerPresenter %}

--- a/server/views/partials/serviceUserBanner.njk
+++ b/server/views/partials/serviceUserBanner.njk
@@ -1,12 +1,3 @@
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-
-{{ govukPhaseBanner({
-  tag: {
-    text: "Prototype"
-  },
-  html: 'This is a new service - your <a class="govuk-link" href="#">feedback</a> will help us improve it.'
-}) }}
-
 <section class="key-details-bar" aria-label="Key details">
   <div class="key-details-bar__key-details govuk-width-container govuk-body">
     <div class="prisoner-info">


### PR DESCRIPTION
Beta banner added to all pages. It sits above the main menu (Home, Caselist, Groups)

<img width="1334" height="721" alt="Screenshot 2026-04-21 at 11 03 20" src="https://github.com/user-attachments/assets/6ba4043c-a309-48a6-bf2f-03bf8daca754" />

