### PR TITLE
Caselist h1 added to the caselist page and updated tests

### DIFF
--- a/server/caselist/caselistPresenter.test.ts
+++ b/server/caselist/caselistPresenter.test.ts
@@ -314,6 +314,30 @@ describe('resultsText', () => {
   })
 })
 
+describe('text', () => {
+  it('should return the expected page heading and sub heading text', () => {
+    const filter = { status: undefined, cohort: undefined, crnOrPersonName: undefined } as CaselistFilter
+    const referralCaseListItemPage: Page<ReferralCaseListItem> = pageFactory
+      .pageContent([])
+      .build({ totalElements: 0, number: 0, size: 10, numberOfElements: 0 }) as Page<ReferralCaseListItem>
+    const presenter = new CaselistPresenter(
+      1,
+      referralCaseListItemPage,
+      filter,
+      '',
+      true,
+      TestUtils.createCaseListFilters(),
+      0,
+      'test location',
+    )
+
+    expect(presenter.text).toEqual({
+      pageSubHeading: 'Building Choices: moderate intensity',
+      pageHeading: 'Case list',
+    })
+  })
+})
+
 describe('generateTableRows', () => {
   const caseListFilters = TestUtils.createCaseListFilters()
 

--- a/server/caselist/caselistPresenter.ts
+++ b/server/caselist/caselistPresenter.ts
@@ -46,8 +46,8 @@ export default class CaselistPresenter {
 
   get text() {
     return {
-      pageHeading: `Building Choices: moderate intensity`,
-      pageCaption: `Referrals in ${this.userLocationDescription}`,
+      pageSubHeading: `Building Choices: moderate intensity`,
+      pageHeading: `Case list`,
     }
   }
 

--- a/server/group/groupPresenter.test.ts
+++ b/server/group/groupPresenter.test.ts
@@ -362,6 +362,29 @@ describe('resultsText', () => {
   })
 })
 
+describe('text', () => {
+  it('should return the expected page heading and sub heading text', () => {
+    const filter = GroupListFilter.empty()
+    const pagedGroups: Page<Group> = pageFactory
+      .pageContent([])
+      .build({ totalElements: 0, number: 0, size: 10, numberOfElements: 0 }) as Page<Group>
+    const presenter = new GroupPresenter(
+      pagedGroups,
+      GroupListPageSection.NOT_STARTED_OR_IN_PROGRESS,
+      0,
+      'Region',
+      filter,
+      [],
+      [],
+    )
+
+    expect(presenter.text).toEqual({
+      pageSubHeading: 'Building Choices: moderate intensity',
+      pageHeading: 'Groups',
+    })
+  })
+})
+
 describe('date formatting helpers', () => {
   describe('getGroupDate', () => {
     it('should prioritize earliestStartDate for NOT_STARTED groups', () => {

--- a/server/views/caselist/caselist.njk
+++ b/server/views/caselist/caselist.njk
@@ -15,8 +15,8 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{ text.pageCaption }}</span>
-      <h1 class="govuk-heading-l">{{ text.pageHeading }}</h1>
+      <span class="govuk-caption-xl">{{ text.pageSubHeading }}</span>
+      <h1 class="govuk-heading-xl">{{ text.pageHeading }}</h1>
     </div>
   </div>
   <div class="govuk-grid-row">


### PR DESCRIPTION
'Case list' added as an H1

Figma: https://www.figma.com/design/Y1h09XHyEI9O8KZoOpvlTS/Accredited-Programmes--Community-?node-id=12903-64636&t=ligINKQl7D2H6fw1-1

After:
<img width="1286" height="931" alt="Screenshot 2026-04-21 at 13 10 58" src="https://github.com/user-attachments/assets/3014f3cf-2ee5-4785-a463-b37d5b58d84f" />


Before:
<img width="1286" height="931" alt="Screenshot 2026-04-21 at 13 11 58" src="https://github.com/user-attachments/assets/f92b0211-f840-4f28-8058-7bf015c8afcc" />

