### PR TITLE
updated footer

### DIFF
--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -1,5 +1,6 @@
 {% from "components/custom-primary-navigation/macro.njk" import customPrimaryNavigation %}
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
+{%- from "moj/components/domain-specific/probation/footer/macro.njk" import pdsFooter -%}
 {% extends "govuk/template.njk" %}
 
 {% block head %}
@@ -23,6 +24,12 @@
       {% endif %}
     {% endblock %}
   {% endif %}
+{% endblock %}
+
+{% block footer %}
+  {{ pdsFooter({
+    baseUrl: '#'
+  }) }}
 {% endblock %}
 
 {% block bodyStart %}


### PR DESCRIPTION
The footer has been updated to use the new MOJ component: https://design-patterns.service.justice.gov.uk/probation/components/pds-footer/

As documented in the Figma: https://www.figma.com/design/Y1h09XHyEI9O8KZoOpvlTS/Accredited-Programmes--Community-?node-id=12903-64632&t=Y6peEA0Ai70Fjh1d-1

<img width="2094" height="1101" alt="Screenshot 2026-04-21 at 13 25 34" src="https://github.com/user-attachments/assets/06dbd8fe-96b2-40cc-9004-045f5f4b3f96" />

I'm wondering about the different grey colours on the page now. But we can ask in the design review.

