### PR TITLE
update incorrect tag name

### DIFF
--- a/server/editSession/editSessionPresenter.test.ts
+++ b/server/editSession/editSessionPresenter.test.ts
@@ -19,7 +19,7 @@ describe('EditSessionPresenter', () => {
               referralId: '123',
               name: 'Alex River',
               crn: 'CRN001',
-              attendance: 'Attended - Complied',
+              attendance: 'Attended',
               sessionNotes: 'Good participation',
             },
             {
@@ -48,7 +48,7 @@ describe('EditSessionPresenter', () => {
               value: '123',
               cells: [
                 { html: '<a href="/referral-details/123/personal-details">Alex River</a> CRN001' },
-                { html: '<span class="govuk-tag govuk-tag--blue">Attended - Complied</span>' },
+                { html: '<span class="govuk-tag govuk-tag--blue">Attended</span>' },
                 {
                   html: '<a href="/group/group-123/session/session-456/session-1/session-notes?referralId=123&source=edit-session">Session 1 notes</a>',
                 },
@@ -120,7 +120,7 @@ describe('EditSessionPresenter', () => {
               referralId: '123',
               name: 'Alex River',
               crn: 'CRN001',
-              attendance: 'Attended - Complied',
+              attendance: 'Attended',
               sessionNotes: '',
             },
           ],
@@ -138,7 +138,7 @@ describe('EditSessionPresenter', () => {
           rows: [
             [
               { html: '<a href="/referral-details/123/personal-details">Alex River</a> CRN001' },
-              { html: '<span class="govuk-tag govuk-tag--blue">Attended - Complied</span>' },
+              { html: '<span class="govuk-tag govuk-tag--blue">Attended</span>' },
               {
                 text: 'Not added',
               },
@@ -158,7 +158,7 @@ describe('EditSessionPresenter', () => {
               referralId: '123',
               name: 'Alex River',
               crn: 'CRN001',
-              attendance: 'Attended - Complied',
+              attendance: 'Attended',
               sessionNotes: 'Not added',
             },
           ],
@@ -176,7 +176,7 @@ describe('EditSessionPresenter', () => {
           rows: [
             [
               { html: '<a href="/referral-details/123/personal-details">Alex River</a> CRN001' },
-              { html: '<span class="govuk-tag govuk-tag--blue">Attended - Complied</span>' },
+              { html: '<span class="govuk-tag govuk-tag--blue">Attended</span>' },
               {
                 text: 'Not added',
               },
@@ -220,7 +220,7 @@ describe('EditSessionPresenter', () => {
               referralId: '123',
               name: 'Alex River',
               crn: 'CRN001',
-              attendance: 'Attended - Complied',
+              attendance: 'Attended',
               sessionNotes: 'Notes recorded',
             },
           ],
@@ -238,7 +238,7 @@ describe('EditSessionPresenter', () => {
           rows: [
             [
               { html: '<a href="/referral-details/123/personal-details">Alex River</a> CRN001' },
-              { html: '<span class="govuk-tag govuk-tag--blue">Attended - Complied</span>' },
+              { html: '<span class="govuk-tag govuk-tag--blue">Attended</span>' },
               {
                 html: '<a href="/group/group-123/session/session-456/pre-group-one-to-one/session-notes?referralId=123&source=edit-session">Pre-group one-to-one notes</a>',
               },

--- a/server/utils/attendanceUtils.test.ts
+++ b/server/utils/attendanceUtils.test.ts
@@ -7,7 +7,7 @@ describe('attendanceUtils', () => {
         attendanceState: '<span class="govuk-tag govuk-tag--blue">Attended</span>',
       })
 
-      expect(attendanceOptionText('Attended - Complied')).toEqual({
+      expect(attendanceOptionText('Attended')).toEqual({
         attendanceState: '<span class="govuk-tag govuk-tag--blue">Attended</span>',
       })
     })
@@ -47,8 +47,8 @@ describe('attendanceUtils', () => {
     })
 
     it('renders a custom attended label when requested', () => {
-      expect(attendanceOptionText('ATTC', { attendedLabel: 'Attended - Complied' })).toEqual({
-        attendanceState: '<span class="govuk-tag govuk-tag--blue">Attended - Complied</span>',
+      expect(attendanceOptionText('ATTC', { attendedLabel: 'Attended' })).toEqual({
+        attendanceState: '<span class="govuk-tag govuk-tag--blue">Attended</span>',
       })
     })
 

--- a/server/utils/attendanceUtils.ts
+++ b/server/utils/attendanceUtils.ts
@@ -27,7 +27,7 @@ const ATTENDANCE_STATUS_BY_VALUE: Record<string, AttendanceStatus> = {
 
 export const attendanceOptionTextTags: Record<'attendanceSessionNotes' | 'editSession', AttendanceOptionTextOptions> = {
   attendanceSessionNotes: { fallbackStatus: 'notAttended' },
-  editSession: { attendedLabel: 'Attended - Complied' },
+  editSession: { attendedLabel: 'Attended' },
 }
 
 export default function attendanceOptionText(


### PR DESCRIPTION
Attendance session and Notes - The tag for 'Attended' was updated from 'Attended  complied' to 'Attended' to reflect the Figma. 

Before:
<img width="627" height="619" alt="Screenshot 2026-04-21 at 16 31 58" src="https://github.com/user-attachments/assets/a77bf6f8-30d0-40d9-8a5b-df107c431a66" />

After:

<img width="922" height="656" alt="Screenshot 2026-04-21 at 16 32 30" src="https://github.com/user-attachments/assets/fb8f1e63-54b6-40d1-a3b4-ad458aba687c" />
