### PR TITLE
heading name updated from Active alerts to NDelius risk flags (regist…

### DIFF
--- a/server/risksAndNeeds/risksAndAlerts/risksAndAlertsOgrs4View.ts
+++ b/server/risksAndNeeds/risksAndAlerts/risksAndAlertsOgrs4View.ts
@@ -182,7 +182,7 @@ export default class RisksAndAlertsOgrs4View {
 
   get importedFromNdeliusText(): InsetTextArgs {
     return {
-      text: `Imported from Nomis on ${this.presenter.risks.dateRetrieved}, last updated on ${this.presenter.risks.assessmentCompleted}`,
+      text: `Imported from NDelius on ${this.presenter.risks.dateRetrieved}, last updated on ${this.presenter.risks.assessmentCompleted}`,
       classes: 'govuk-!-margin-top-8',
     }
   }

--- a/server/risksAndNeeds/risksAndAlerts/risksAndAlertsView.ts
+++ b/server/risksAndNeeds/risksAndAlerts/risksAndAlertsView.ts
@@ -14,7 +14,7 @@ export default class RisksAndAlertsView {
 
   get importedFromNdeliusText(): InsetTextArgs {
     return {
-      text: `Imported from Nomis on ${this.presenter.risks.dateRetrieved}, last updated on ${this.presenter.risks.assessmentCompleted}`,
+      text: `Imported from NDelius on ${this.presenter.risks.dateRetrieved}, last updated on ${this.presenter.risks.assessmentCompleted}`,
       classes: 'govuk-!-margin-top-8',
     }
   }

--- a/server/views/components/risk-flag-widget/template.njk
+++ b/server/views/components/risk-flag-widget/template.njk
@@ -1,5 +1,5 @@
 <aside class="risk-flag-widget" aria-label="active risk flags">
-  <h3 class="govuk-heading-s">Active alerts</h3>
+  <h3 class="govuk-heading-s">NDelius risk flags (registers)</h3>
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
   {% if params.flags != null %}
   {% if params.flags.length %}


### PR DESCRIPTION
Heading 'Active alerts' updated to 'NDelius risk flags (registers)' and the text changed from 'Nomis' to 'NDelius in the standout text'.

<img width="922" height="656" alt="Screenshot 2026-04-22 at 09 07 49" src="https://github.com/user-attachments/assets/5ad6182f-4cae-45c4-84e6-1b51c24d07fe" />
