### PR TITLE
APG-1968 Replace `scoreValueText` with `PresenterUtils.scoreValueText`

### DIFF
--- a/server/pni/pniPresenter.test.ts
+++ b/server/pni/pniPresenter.test.ts
@@ -1,5 +1,6 @@
 import { PniScore, ReferralDetails } from '@manage-and-deliver-api'
 import PniPresenter from './pniPresenter'
+import PresenterUtils from '../utils/presenterUtils'
 import pniScoreFactory from '../testutils/factories/pniScoreFactory'
 import referralDetailsFactory from '../testutils/factories/referralDetailsFactory'
 
@@ -147,11 +148,10 @@ describe('PniPresenter', () => {
   })
 
   describe('scoreValueText', () => {
-    const presenter = new PniPresenter('12345', referralDetails, pniScore)
     it('returns the string representation of the given score', () => {
-      expect(presenter.scoreValueText(0)).toBe('0')
-      expect(presenter.scoreValueText(null)).toBe('Score missing')
-      expect(presenter.scoreValueText(undefined)).toBe('Score missing')
+      expect(PresenterUtils.scoreValueText(0)).toBe('0')
+      expect(PresenterUtils.scoreValueText(null)).toBe('Score missing')
+      expect(PresenterUtils.scoreValueText(undefined)).toBe('Score missing')
     })
   })
 

--- a/server/pni/pniPresenter.ts
+++ b/server/pni/pniPresenter.ts
@@ -1,5 +1,6 @@
 import { PniScore, ReferralDetails } from '@manage-and-deliver-api'
 import ReferralLayoutPresenter, { HorizontalNavValues } from '../shared/referral/referralLayoutPresenter'
+import PresenterUtils from '../utils/presenterUtils'
 
 export default class PniPresenter extends ReferralLayoutPresenter {
   constructor(
@@ -10,10 +11,6 @@ export default class PniPresenter extends ReferralLayoutPresenter {
     readonly isCohortUpdated: boolean | null = null,
   ) {
     super(HorizontalNavValues.programmeNeedsIdentifierTab, referral, isLdcUpdated, isCohortUpdated)
-  }
-
-  scoreValueText(value?: number | null): string {
-    return value?.toString() || 'Score missing'
   }
 
   needScoreToString(needScore: string): string {
@@ -41,7 +38,7 @@ export default class PniPresenter extends ReferralLayoutPresenter {
             text: '11.11 - Sexual preoccupation',
           },
           value: {
-            text: this.scoreValueText(sexDomainScores.individualSexScores.sexualPreOccupation),
+            text: PresenterUtils.scoreValueText(sexDomainScores.individualSexScores.sexualPreOccupation),
           },
         },
         {
@@ -49,7 +46,7 @@ export default class PniPresenter extends ReferralLayoutPresenter {
             text: '11.12 - Offence-related sexual interests',
           },
           value: {
-            text: this.scoreValueText(sexDomainScores.individualSexScores.offenceRelatedSexualInterests),
+            text: PresenterUtils.scoreValueText(sexDomainScores.individualSexScores.offenceRelatedSexualInterests),
           },
         },
         {
@@ -57,7 +54,7 @@ export default class PniPresenter extends ReferralLayoutPresenter {
             text: '6.12 - Emotional congruence with children or feeling closer to children than adults',
           },
           value: {
-            text: this.scoreValueText(sexDomainScores.individualSexScores.emotionalCongruence),
+            text: PresenterUtils.scoreValueText(sexDomainScores.individualSexScores.emotionalCongruence),
           },
         },
         {
@@ -87,7 +84,7 @@ export default class PniPresenter extends ReferralLayoutPresenter {
             text: '12.1 - Pro-criminal attitudes',
           },
           value: {
-            text: this.scoreValueText(thinkingDomainScores.individualThinkingScores.proCriminalAttitudes),
+            text: PresenterUtils.scoreValueText(thinkingDomainScores.individualThinkingScores.proCriminalAttitudes),
           },
         },
         {
@@ -95,7 +92,7 @@ export default class PniPresenter extends ReferralLayoutPresenter {
             text: '12.9 - Hostile orientation',
           },
           value: {
-            text: this.scoreValueText(thinkingDomainScores.individualThinkingScores.hostileOrientation),
+            text: PresenterUtils.scoreValueText(thinkingDomainScores.individualThinkingScores.hostileOrientation),
           },
         },
         {
@@ -125,7 +122,9 @@ export default class PniPresenter extends ReferralLayoutPresenter {
             text: '6.1 - Current relationship with close family',
           },
           value: {
-            text: this.scoreValueText(relationshipsDomainScores.individualRelationshipScores.curRelCloseFamily),
+            text: PresenterUtils.scoreValueText(
+              relationshipsDomainScores.individualRelationshipScores.curRelCloseFamily,
+            ),
           },
         },
         {
@@ -133,7 +132,9 @@ export default class PniPresenter extends ReferralLayoutPresenter {
             text: '6.6 - Previous experience of close relationships',
           },
           value: {
-            text: this.scoreValueText(relationshipsDomainScores.individualRelationshipScores.prevCloseRelationships),
+            text: PresenterUtils.scoreValueText(
+              relationshipsDomainScores.individualRelationshipScores.prevCloseRelationships,
+            ),
           },
         },
         {
@@ -141,7 +142,9 @@ export default class PniPresenter extends ReferralLayoutPresenter {
             text: '7.3 - Easily influenced by criminal associates',
           },
           value: {
-            text: this.scoreValueText(relationshipsDomainScores.individualRelationshipScores.easilyInfluenced),
+            text: PresenterUtils.scoreValueText(
+              relationshipsDomainScores.individualRelationshipScores.easilyInfluenced,
+            ),
           },
         },
         {
@@ -149,7 +152,7 @@ export default class PniPresenter extends ReferralLayoutPresenter {
             text: '11.3 - Aggressive or controlling behaviour',
           },
           value: {
-            text: this.scoreValueText(
+            text: PresenterUtils.scoreValueText(
               relationshipsDomainScores.individualRelationshipScores.aggressiveControllingBehaviour,
             ),
           },
@@ -181,7 +184,7 @@ export default class PniPresenter extends ReferralLayoutPresenter {
             text: '11.2 - Impulsivity',
           },
           value: {
-            text: this.scoreValueText(selfManagementDomainScores.individualSelfManagementScores.impulsivity),
+            text: PresenterUtils.scoreValueText(selfManagementDomainScores.individualSelfManagementScores.impulsivity),
           },
         },
         {
@@ -189,7 +192,9 @@ export default class PniPresenter extends ReferralLayoutPresenter {
             text: '11.4 - Temper control',
           },
           value: {
-            text: this.scoreValueText(selfManagementDomainScores.individualSelfManagementScores.temperControl),
+            text: PresenterUtils.scoreValueText(
+              selfManagementDomainScores.individualSelfManagementScores.temperControl,
+            ),
           },
         },
         {
@@ -197,7 +202,9 @@ export default class PniPresenter extends ReferralLayoutPresenter {
             text: '11.6 - Problem-solving skills',
           },
           value: {
-            text: this.scoreValueText(selfManagementDomainScores.individualSelfManagementScores.problemSolvingSkills),
+            text: PresenterUtils.scoreValueText(
+              selfManagementDomainScores.individualSelfManagementScores.problemSolvingSkills,
+            ),
           },
         },
         {
@@ -205,7 +212,9 @@ export default class PniPresenter extends ReferralLayoutPresenter {
             text: '10.1 - Difficulties coping',
           },
           value: {
-            text: this.scoreValueText(selfManagementDomainScores.individualSelfManagementScores.difficultiesCoping),
+            text: PresenterUtils.scoreValueText(
+              selfManagementDomainScores.individualSelfManagementScores.difficultiesCoping,
+            ),
           },
         },
         {

--- a/server/risksAndNeeds/learningNeeds/learningNeedsPresenter.ts
+++ b/server/risksAndNeeds/learningNeeds/learningNeedsPresenter.ts
@@ -43,7 +43,7 @@ export default class LearningNeedsPresenter extends RisksAndNeedsPresenter {
   }
 
   learningNeedsScoreSummaryList(): SummaryListItem[] {
-    const ldcScore = this.learningNeeds.ldcScore.toString()
+    const ldcScore = PresenterUtils.scoreValueText(this.learningNeeds.ldcScore)
     return [
       {
         key: 'Calculated score',

--- a/server/risksAndNeeds/risksAndNeedsController.test.ts
+++ b/server/risksAndNeeds/risksAndNeedsController.test.ts
@@ -120,6 +120,19 @@ describe('Learning Needs', () => {
       return request(app).get(`/referral/${referralId}/learning-needs`).expect(200)
     })
 
+    it('renders Score missing when ldcScore is null', async () => {
+      const learningNeeds: LearningNeeds = learningNeedsFactory.build({ ldcScore: null })
+      accreditedProgrammesManageAndDeliverService.getLearningNeeds.mockResolvedValue(learningNeeds)
+
+      const referralId = randomUUID()
+      return request(app)
+        .get(`/referral/${referralId}/learning-needs`)
+        .expect(200)
+        .expect(res => {
+          expect(res.text).toContain('Score missing')
+        })
+    })
+
     it('calls the service with correct parameters', async () => {
       const learningNeeds: LearningNeeds = learningNeedsFactory.build()
       accreditedProgrammesManageAndDeliverService.getLearningNeeds.mockResolvedValue(learningNeeds)

--- a/server/utils/presenterUtils.test.ts
+++ b/server/utils/presenterUtils.test.ts
@@ -375,6 +375,14 @@ describe(PresenterUtils, () => {
     })
   })
 
+  describe('.scoreValueText', () => {
+    it('returns the string representation of the given score', () => {
+      expect(PresenterUtils.scoreValueText(0)).toBe('0')
+      expect(PresenterUtils.scoreValueText(null)).toBe('Score missing')
+      expect(PresenterUtils.scoreValueText(undefined)).toBe('Score missing')
+    })
+  })
+
   describe('twelveHourTimeValue', () => {
     describe('hour, minute values', () => {
       describe('when the model has a null value for the property', () => {

--- a/server/utils/presenterUtils.ts
+++ b/server/utils/presenterUtils.ts
@@ -101,6 +101,10 @@ export default class PresenterUtils {
     return value ? 'Yes' : 'No'
   }
 
+  static scoreValueText(value?: number | null): string {
+    return value?.toString() || 'Score missing'
+  }
+
   twelveHourTimeValue(
     modelValue: {
       hour?: number


### PR DESCRIPTION
- Fix to handle a null ldcScore value from the API appropriately
- Refactored all instances of `scoreValueText` in presenters and tests to use `PresenterUtils.scoreValueText`, ensuring consistency and code reusability across the codebase.