### PR TITLE
Adding in Risk of serious harm heading

### DIFF
--- a/server/views/risksAndNeeds/risksAndAlertsOgrs4.njk
+++ b/server/views/risksAndNeeds/risksAndAlertsOgrs4.njk
@@ -35,6 +35,8 @@
     {{ expandedPredictorBadge(seriousViolentReoffendingPredictor, true, false) }}
     {{ expandedPredictorBadge(directContactSexualReoffendingPredictor, true, false) }}
     {{ expandedPredictorBadge(imagesAndIndirectContactSexualReoffendingPredictor, true, false) }}
+
+    <h2 class="govuk-heading-m">Risk of serious harm</h2>
     {{ roshWidget(roshRiskSummary) }}
     {{ govukInsetText(importedFromNdeliusText) }}
 


### PR DESCRIPTION
'Risk of serious harm' heading was missing on the OGRS4 risk page
<img width="961" height="433" alt="Screenshot 2026-04-22 at 16 32 17" src="https://github.com/user-attachments/assets/8e7fdb01-bc23-487a-9ce6-32b750b09adb" />
