### PR TITLE
Group details text update for empty state

### DIFF
--- a/server/groupDetails/groupDetailsPresenter.ts
+++ b/server/groupDetails/groupDetailsPresenter.ts
@@ -78,7 +78,7 @@ export default class GroupDetailsPresenter extends GroupServiceLayoutPresenter {
             ? [
                 `${this.group.currentlyAllocatedNumber.toString()} participant${this.group.currentlyAllocatedNumber > 1 ? 's' : ''}`,
               ]
-            : ['No people added'],
+            : ['No people allocated'],
       },
     ]
   }


### PR DESCRIPTION
Text updated from 'No people added' to 'No people allocated' in Group details page.

See figma: https://www.figma.com/design/Y1h09XHyEI9O8KZoOpvlTS/Accredited-Programmes--Community-?node-id=10551-51791&t=VCbFusmcieJUSAZo-1

Before:
<img width="944" height="731" alt="Screenshot 2026-04-23 at 15 54 07" src="https://github.com/user-attachments/assets/5fe3b2cc-dc40-496c-9f44-8b892e5961c0" />

After:

<img width="944" height="727" alt="Screenshot 2026-04-23 at 15 54 56" src="https://github.com/user-attachments/assets/194dbbf0-4392-46bd-b12d-a796bdcc7699" />
