### PR TITLE
Maintain the previous input value when there is a form error

### DIFF
--- a/server/createGroup/editGroupController.test.ts
+++ b/server/createGroup/editGroupController.test.ts
@@ -95,6 +95,20 @@ describe('Edit Group Controller', () => {
           expect(res.text).toContain('Enter or select a date')
         })
     })
+
+    it('displays user input when date validation fails', async () => {
+      accreditedProgrammesManageAndDeliverService.getGroupDetailsById.mockResolvedValue(groupDetails)
+
+      return request(app)
+        .post(`/group/${groupId}/edit-group-start-date`)
+        .type('form')
+        .send({ 'create-group-date': '32/13/2026' })
+        .expect(400)
+        .expect(res => {
+          expect(res.text).toContain('32/13/2026')
+          expect(res.text).toContain('Enter a date in the format 10/7/2025')
+        })
+    })
   })
 
   describe('GET /group/:groupId/edit-start-date-rescheduled', () => {

--- a/server/createGroup/editGroupController.ts
+++ b/server/createGroup/editGroupController.ts
@@ -51,6 +51,7 @@ export default class EditGroupController extends BaseController {
       if (data.error) {
         res.status(400)
         formError = data.error
+        groupData.earliestStartDate = req.body['create-group-date']
       } else {
         req.session.createGroupFormData = {
           ...groupData,


### PR DESCRIPTION
Maintain the previous input value when there is a form error on the edit group date page