### PR TITLE
Attendance History Tweaks

### DIFF
--- a/server/@types/manageAndDeliverApi/imported/index.d.ts
+++ b/server/@types/manageAndDeliverApi/imported/index.d.ts
@@ -3105,9 +3105,9 @@ export interface components {
       first?: boolean
       last?: boolean
       sort?: components['schemas']['SortObject']
+      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
-      pageable?: components['schemas']['PageableObject']
       empty?: boolean
     }
     PageableObject: {
@@ -3115,10 +3115,10 @@ export interface components {
       offset?: number
       sort?: components['schemas']['SortObject']
       /** Format: int32 */
-      pageSize?: number
+      pageNumber?: number
       paged?: boolean
       /** Format: int32 */
-      pageNumber?: number
+      pageSize?: number
       unpaged?: boolean
     }
     ReferralCaseListItem: {
@@ -3635,6 +3635,11 @@ export interface components {
        */
       date: string
       /**
+       * Format: date-time
+       * @description The unformatted date of the session for sorting
+       */
+      unformattedDate: string
+      /**
        * @description The time range of the session
        * @example 10:30am to 11am
        */
@@ -3759,9 +3764,9 @@ export interface components {
       first?: boolean
       last?: boolean
       sort?: components['schemas']['SortObject']
+      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
-      pageable?: components['schemas']['PageableObject']
       empty?: boolean
     }
     GroupItem: {
@@ -3854,9 +3859,9 @@ export interface components {
       first?: boolean
       last?: boolean
       sort?: components['schemas']['SortObject']
+      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
-      pageable?: components['schemas']['PageableObject']
       empty?: boolean
     }
     /** @description Details of a Programme Group including filters and paginated group data. */
@@ -4358,21 +4363,12 @@ export interface components {
        * @example 9
        */
       currentlyAllocatedNumber: number
-      /**
-       * @description The treatment manager for this group.
-       * @example Chloe Pascal
-       */
-      treatmentManager: string
-      /**
-       * @description The list of facilitators for this group.
-       * @example [Harpreet Singh, Tom Bassett]
-       */
-      facilitators: string[]
-      /**
-       * @description The list of coverFacilitators for this group.
-       * @example [Tom Saunders]
-       */
-      coverFacilitators?: string[] | null
+      /** @description The treatment manager for this group. */
+      treatmentManager: components['schemas']['CreateGroupTeamMember']
+      /** @description The list of facilitators for this group. */
+      facilitators: components['schemas']['CreateGroupTeamMember'][]
+      /** @description The list of coverFacilitators for this group. */
+      coverFacilitators?: components['schemas']['CreateGroupTeamMember'][] | null
     }
   }
   responses: never

--- a/server/groupDetails/groupDetailsPresenter.ts
+++ b/server/groupDetails/groupDetailsPresenter.ts
@@ -99,18 +99,22 @@ export default class GroupDetailsPresenter extends GroupServiceLayoutPresenter {
   }
 
   getGroupStaffSummary(): SummaryListItem[] {
+    const facilitators = this.group.facilitators.map(f => f.facilitator)
+    const coverFacilitators =
+      this.group.coverFacilitators.length > 0 ? this.group.coverFacilitators.map(f => f.facilitator) : ['None added']
+
     return [
       {
         key: 'Treatment Manager',
-        lines: [this.group.treatmentManager],
+        lines: [this.group.treatmentManager?.facilitator],
       },
       {
         key: 'Facilitators',
-        lines: this.group.facilitators,
+        lines: facilitators,
       },
       {
         key: 'Cover facilitators',
-        lines: this.group.coverFacilitators.length > 0 ? this.group.coverFacilitators : ['None added'],
+        lines: coverFacilitators,
       },
     ]
   }

--- a/server/referralDetails/attendanceHistory/attendanceHistoryPresenter.test.ts
+++ b/server/referralDetails/attendanceHistory/attendanceHistoryPresenter.test.ts
@@ -65,6 +65,11 @@ describe('AttendanceHistoryPresenter', () => {
       const rows = presenter.attendanceHistoryTableArgs
 
       expect(rows).toHaveLength(2)
+
+      // Calculate expected epoch times from the unformatted dates
+      const session1EpochTime = new Date('2025-07-11 10:30:00').getTime()
+      const session2EpochTime = new Date('2025-07-18 14:00:00').getTime()
+
       expect(rows[0]).toEqual([
         {
           html: `<a href="/group/1234567890/session/session-1/edit-session?isAttendanceHistory=true&referralId=${referralId}" class="govuk-link">Pre-group one-to-one</a>`,
@@ -73,7 +78,7 @@ describe('AttendanceHistoryPresenter', () => {
         {
           text: '11 July 2025',
           attributes: {
-            'data-sort-value': 1752226200000,
+            'data-sort-value': session1EpochTime,
           },
         },
         { text: 'Midday to 1pm' },
@@ -90,7 +95,7 @@ describe('AttendanceHistoryPresenter', () => {
         {
           text: '18 July 2025',
           attributes: {
-            'data-sort-value': 1752843600000,
+            'data-sort-value': session2EpochTime,
           },
         },
         { text: '2pm to 3pm' },

--- a/server/referralDetails/attendanceHistory/attendanceHistoryPresenter.test.ts
+++ b/server/referralDetails/attendanceHistory/attendanceHistoryPresenter.test.ts
@@ -70,8 +70,13 @@ describe('AttendanceHistoryPresenter', () => {
           html: `<a href="/group/1234567890/session/session-1/edit-session?isAttendanceHistory=true&referralId=${referralId}" class="govuk-link">Pre-group one-to-one</a>`,
         },
         { text: 'GRP-001' },
-        { text: '11 July 2025' },
-        { text: '10:30am to 11am' },
+        {
+          text: '11 July 2025',
+          attributes: {
+            'data-sort-value': 1752226200000,
+          },
+        },
+        { text: 'Midday to 1pm' },
         { html: `<span class="govuk-tag govuk-tag--blue">Attended</span>` },
         {
           html: `<a href="/group/1234567890/session/session-1/pre-group-one-to-one/session-notes?referralId=${referralId}&isAttendanceHistory=true" class="govuk-link">Pre-group one-to-one attendance and notes</a>`,
@@ -82,7 +87,12 @@ describe('AttendanceHistoryPresenter', () => {
           html: `<a href="/group/1234567890/session/session-2/edit-session?isAttendanceHistory=true&referralId=${referralId}" class="govuk-link">Session 1: Introduction</a>`,
         },
         { text: 'GRP-001' },
-        { text: '18 July 2025' },
+        {
+          text: '18 July 2025',
+          attributes: {
+            'data-sort-value': 1752843600000,
+          },
+        },
         { text: '2pm to 3pm' },
         { html: `<span class="govuk-tag govuk-tag--red">Not attended</span>` },
         { text: 'Not added' },
@@ -98,6 +108,7 @@ describe('AttendanceHistoryPresenter', () => {
             groupCode: null as unknown as string,
             date: '11 July 2025',
             time: '10:30am',
+            unformattedDate: '2025-07-11 10:30:00.00',
             attendanceStatus: 'Attended',
             hasNotes: false,
             popName: '',

--- a/server/referralDetails/attendanceHistory/attendanceHistoryPresenter.ts
+++ b/server/referralDetails/attendanceHistory/attendanceHistoryPresenter.ts
@@ -76,8 +76,8 @@ export default class AttendanceHistoryPresenter extends ReferralLayoutPresenter 
         html: `<a href="/group/${session.groupId}/session/${session.sessionId}/edit-session?isAttendanceHistory=true&referralId=${this.referralId}" class="govuk-link">${session.sessionName}</a>`,
       },
       { text: session.groupCode ?? 'N/A' },
-      { text: session.date },
-      { text: session.time },
+      { text: session.date, attributes: { 'data-sort-value': new Date(session.unformattedDate).getTime() } },
+      { text: session.time.charAt(0).toUpperCase() + session.time.slice(1) },
       { html: attendanceTag(session.attendanceStatus) },
       session.hasNotes
         ? {

--- a/server/referralDetails/attendanceHistory/attendanceHistoryView.ts
+++ b/server/referralDetails/attendanceHistory/attendanceHistoryView.ts
@@ -20,7 +20,7 @@ export default class AttendanceHistoryView {
         {
           text: 'Session',
           attributes: {
-            'aria-sort': 'ascending',
+            'aria-sort': 'none',
           },
         },
         {

--- a/server/testutils/factories/attendanceHistoryResponseFactory.ts
+++ b/server/testutils/factories/attendanceHistoryResponseFactory.ts
@@ -35,11 +35,12 @@ export default AttendanceHistoryResponseFactory.define(({ sequence }) => ({
       groupCode: 'GRP-001',
       groupId: '1234567890',
       date: '11 July 2025',
-      time: '10:30am to 11am',
+      time: 'midday to 1pm',
       attendanceStatus: 'Attended - Complied',
       hasNotes: true,
       popName: '',
       isCatchup: false,
+      unformattedDate: '2025-07-11 10:30:00',
     },
     {
       sessionId: 'session-2',
@@ -52,6 +53,7 @@ export default AttendanceHistoryResponseFactory.define(({ sequence }) => ({
       hasNotes: false,
       popName: '',
       isCatchup: false,
+      unformattedDate: '2025-07-18 14:00:00',
     },
   ],
 }))

--- a/server/testutils/factories/groupDetailsFactory.ts
+++ b/server/testutils/factories/groupDetailsFactory.ts
@@ -16,7 +16,36 @@ export default GroupDetailsFactory.define(({ sequence }) => ({
   sex: 'MALE' as Group['sex'],
   daysAndTimes: ['Mondays 10am to 12:30pm, Fridays 11am to 1:30pm'],
   currentlyAllocatedNumber: 3,
-  treatmentManager: 'Treatment Manager',
-  facilitators: ['Facilitator 1', 'Facilitator 2'],
-  coverFacilitators: ['Cover Facilitator'],
+  treatmentManager: {
+    facilitator: 'Treatment Manager',
+    facilitatorCode: '1234',
+    teamName: 'Team A',
+    teamCode: '9876',
+    teamMemberType: 'TREATMENT_MANAGER' as 'TREATMENT_MANAGER' | 'REGULAR_FACILITATOR' | 'COVER_FACILITATOR',
+  },
+  facilitators: [
+    {
+      facilitator: 'Facilitator 1',
+      facilitatorCode: '1111',
+      teamName: 'Team A',
+      teamCode: '9876',
+      teamMemberType: 'REGULAR_FACILITATOR' as 'TREATMENT_MANAGER' | 'REGULAR_FACILITATOR' | 'COVER_FACILITATOR',
+    },
+    {
+      facilitator: 'Facilitator 2',
+      facilitatorCode: '2222',
+      teamName: 'Team A',
+      teamCode: '9876',
+      teamMemberType: 'REGULAR_FACILITATOR' as 'TREATMENT_MANAGER' | 'REGULAR_FACILITATOR' | 'COVER_FACILITATOR',
+    },
+  ],
+  coverFacilitators: [
+    {
+      facilitator: 'Cover Facilitator',
+      facilitatorCode: '9876',
+      teamName: 'Team A',
+      teamCode: '9876',
+      teamMemberType: 'COVER_FACILITATOR' as 'TREATMENT_MANAGER' | 'REGULAR_FACILITATOR' | 'COVER_FACILITATOR',
+    },
+  ],
 }))


### PR DESCRIPTION
- Correct date ordering
- Remove session name ordering - sessions are being returned from the API in date order
- Capitalise first letter of time value (e.g. Midday to 1pm)
- Implement changes due to types update of facilitators object