### PR TITLE
remove homepage link from edit group journey

### DIFF
--- a/server/createGroup/check-your-answers/createGroupCyaView.ts
+++ b/server/createGroup/check-your-answers/createGroupCyaView.ts
@@ -12,13 +12,6 @@ export default class CreateGroupCyaView {
     }
   }
 
-  private homePageLink() {
-    return {
-      text: 'Go to Accredited Programmes homepage',
-      href: `/`,
-    }
-  }
-
   get getCreateGroupSummary(): SummaryListArgs {
     return {
       ...ViewUtils.summaryListArgs(this.presenter.getCreateGroupSummary()),
@@ -30,7 +23,6 @@ export default class CreateGroupCyaView {
       'createGroup/createGroupCya',
       {
         backLinkArgs: this.backLinkArgs(),
-        homePageLink: this.homePageLink(),
         createGroupSummary: this.getCreateGroupSummary,
         cancelLink: `/`,
         text: this.presenter.text,

--- a/server/createGroup/code/createOrEditGroupCodeView.ts
+++ b/server/createGroup/code/createOrEditGroupCodeView.ts
@@ -12,13 +12,6 @@ export default class CreateOrEditGroupCodeView {
     }
   }
 
-  private homePageLink() {
-    return {
-      text: 'Go to Accredited Programmes homepage',
-      href: `/`,
-    }
-  }
-
   private createGroupCodeArgs(): InputArgs {
     return {
       id: 'create-group-code',
@@ -41,7 +34,6 @@ export default class CreateOrEditGroupCodeView {
       'createGroup/createGroupCode',
       {
         backLinkArgs: this.backLinkArgs(),
-        homePageLink: this.homePageLink(),
         captionText: this.presenter.captionText,
         createGroupCodeArgs: this.createGroupCodeArgs(),
         errorSummary: ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary),

--- a/server/createGroup/cohort/createOrEditGroupCohortView.ts
+++ b/server/createGroup/cohort/createOrEditGroupCohortView.ts
@@ -13,13 +13,6 @@ export default class CreateGroupCohortView {
     }
   }
 
-  private homePageLink() {
-    return {
-      text: 'Go to Accredited Programmes homepage',
-      href: `/`,
-    }
-  }
-
   private createGroupCohortArgs(): RadiosArgs {
     return {
       name: 'create-group-cohort',
@@ -47,7 +40,6 @@ export default class CreateGroupCohortView {
       'createGroup/createGroupCohort',
       {
         backLinkArgs: this.backLinkArgs(),
-        homePageLink: this.homePageLink(),
         captionText: this.presenter.captionText,
         createGroupCohortArgs: this.createGroupCohortArgs(),
         errorSummary: ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary),

--- a/server/createGroup/date/createOrEditGroupDateView.ts
+++ b/server/createGroup/date/createOrEditGroupDateView.ts
@@ -11,13 +11,6 @@ export default class CreateOrEditGroupDateView {
     }
   }
 
-  private homePageLink() {
-    return {
-      text: 'Go to Accredited Programmes homepage',
-      href: `/`,
-    }
-  }
-
   private get createGroupDateArgs() {
     return {
       id: 'create-group-date',
@@ -41,7 +34,6 @@ export default class CreateOrEditGroupDateView {
       'createGroup/createGroupDate',
       {
         backLinkArgs: this.backLinkArgs(),
-        homePageLink: this.homePageLink(),
         createGroupDateArgs: this.createGroupDateArgs,
         errorSummary: ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary),
         text: this.presenter.text,

--- a/server/createGroup/location/createOrEditGroupLocationView.ts
+++ b/server/createGroup/location/createOrEditGroupLocationView.ts
@@ -12,13 +12,6 @@ export default class CreateOrEditGroupLocationView {
     }
   }
 
-  private homePageLink() {
-    return {
-      text: 'Go to Accredited Programmes homepage',
-      href: `/`,
-    }
-  }
-
   private selectOfficeArgs(): RadiosArgs {
     return {
       name: 'create-group-location',
@@ -62,7 +55,6 @@ export default class CreateOrEditGroupLocationView {
       'createGroup/createGroupLocation',
       {
         backLinkArgs: this.backLinkArgs(),
-        homePageLink: this.homePageLink(),
         errorSummary: ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary),
         text: this.presenter.text,
         selectOfficeArgs: this.selectOfficeArgs(),

--- a/server/createGroup/pdu/createOrEditGroupPduView.ts
+++ b/server/createGroup/pdu/createOrEditGroupPduView.ts
@@ -12,13 +12,6 @@ export default class CreateOrEditGroupPduView {
     }
   }
 
-  private homePageLink() {
-    return {
-      text: 'Go to Accredited Programmes homepage',
-      href: `/`,
-    }
-  }
-
   private createGroupPduArgs(): SelectArgs {
     return {
       id: 'create-group-pdu',
@@ -42,7 +35,6 @@ export default class CreateOrEditGroupPduView {
       'createGroup/createGroupPdu',
       {
         backLinkArgs: this.backLinkArgs(),
-        homePageLink: this.homePageLink(),
         createGroupPduArgs: this.createGroupPduArgs(),
         errorSummary: ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary),
         text: this.presenter.text,

--- a/server/createGroup/sex/createOrEditGroupSexView.ts
+++ b/server/createGroup/sex/createOrEditGroupSexView.ts
@@ -13,13 +13,6 @@ export default class CreateGroupSexView {
     }
   }
 
-  private homePageLink() {
-    return {
-      text: 'Go to Accredited Programmes homepage',
-      href: `/`,
-    }
-  }
-
   private createGroupSexArgs(): RadiosArgs {
     return {
       name: 'create-group-sex',
@@ -44,7 +37,6 @@ export default class CreateGroupSexView {
       'createGroup/createGroupSex',
       {
         backLinkArgs: this.backLinkArgs(),
-        homePageLink: this.homePageLink(),
         captionText: this.presenter.captionText,
         createGroupSexArgs: this.createGroupSexArgs(),
         errorSummary: ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary),

--- a/server/createGroup/start/createGroupStartView.ts
+++ b/server/createGroup/start/createGroupStartView.ts
@@ -10,19 +10,11 @@ export default class CreateGroupStartView {
     }
   }
 
-  private homePageLink() {
-    return {
-      text: 'Go to Accredited Programmes homepage',
-      href: `/`,
-    }
-  }
-
   get renderArgs(): [string, Record<string, unknown>] {
     return [
       'createGroup/createGroupStart',
       {
         backLinkArgs: this.backLinkArgs(),
-        homePageLink: this.homePageLink(),
       },
     ]
   }

--- a/server/createGroup/treatment-manager/createOrEditGroupTreatmentManagerView.ts
+++ b/server/createGroup/treatment-manager/createOrEditGroupTreatmentManagerView.ts
@@ -13,13 +13,6 @@ export default class CreateOrEditGroupTreatmentManagerView {
     }
   }
 
-  private homePageLink() {
-    return {
-      text: 'Go to Accredited Programmes homepage',
-      href: `/`,
-    }
-  }
-
   private createGroupTreatmentManagerArgs(): SelectArgs {
     return {
       id: 'create-group-treatment-manager',
@@ -27,7 +20,7 @@ export default class CreateOrEditGroupTreatmentManagerView {
       label: {
         text: 'Treatment Manager',
         classes: 'govuk-label--m',
-        isPageHeading: true,
+        isPageHeading: false,
       },
       errorMessage: ViewUtils.govukErrorMessage(this.presenter.fields.createGroupTreatmentManager.errorMessage),
       items: this.presenter.generateSelectOptions(
@@ -118,7 +111,6 @@ export default class CreateOrEditGroupTreatmentManagerView {
       'createGroup/createGroupTreatmentManager',
       {
         backLinkArgs: this.backLinkArgs(),
-        homePageLink: this.homePageLink(),
         createGroupTreatmentManagerArgs: this.createGroupTreatmentManagerArgs(),
         createGroupFacilitatorArgs: this.createGroupFacilitatorArgs(),
         createGroupFacilitatorsFieldSetArgs: this.createGroupFacilitatorsFieldSetArgs(),

--- a/server/createGroup/when/createOrEditGroupWhenView.ts
+++ b/server/createGroup/when/createOrEditGroupWhenView.ts
@@ -11,13 +11,6 @@ export default class CreateOrEditGroupWhenView {
     }
   }
 
-  private homePageLink() {
-    return {
-      text: 'Go to Accredited Programmes homepage',
-      href: `/`,
-    }
-  }
-
   private checkboxArgs() {
     return {
       name: 'days-of-week',
@@ -44,7 +37,6 @@ export default class CreateOrEditGroupWhenView {
       'createGroup/createGroupWhen',
       {
         backLinkArgs: this.backLinkArgs(),
-        homePageLink: this.homePageLink(),
         errorSummary: ViewUtils.govukErrorSummaryArgs(this.presenter.errorSummary),
         text: this.presenter.text,
         checkboxArgs: this.checkboxArgs(),

--- a/server/views/createGroup/createGroupCode.njk
+++ b/server/views/createGroup/createGroupCode.njk
@@ -15,9 +15,6 @@
                 <div class="govuk-grid-column-two-thirds">
                   {{ govukBackLink(backLinkArgs) }}
                 </div>
-                <div class="govuk-grid-column-one-third">
-                  <a class="return_to_homepage__link" href={{ homePageLink.href }}>{{ homePageLink.text }}</a>
-                </div>
               </div>
               <div class="govuk-grid-row">
                   <div class="govuk-grid-column-two-thirds">

--- a/server/views/createGroup/createGroupCohort.njk
+++ b/server/views/createGroup/createGroupCohort.njk
@@ -15,9 +15,6 @@
                   <div class="govuk-grid-column-two-thirds">
                     {{ govukBackLink(backLinkArgs) }}
                   </div>
-                  <div class="govuk-grid-column-one-third">
-                    <a class="return_to_homepage__link" href={{ homePageLink.href }}>{{ homePageLink.text }}</a>
-                  </div>
                 </div>
                 <div class="govuk-grid-row">
                     <div class="govuk-grid-column-two-thirds">

--- a/server/views/createGroup/createGroupCya.njk
+++ b/server/views/createGroup/createGroupCya.njk
@@ -15,9 +15,6 @@
                   <div class="govuk-grid-column-two-thirds">
                     {{ govukBackLink(backLinkArgs) }}
                   </div>
-                  <div class="govuk-grid-column-one-third">
-                    <a class="return_to_homepage__link" href={{ homePageLink.href }}>{{ homePageLink.text }}</a>
-                  </div>
                 </div>
                 <div class="govuk-grid-row">
                     <div class="govuk-grid-column-two-thirds">

--- a/server/views/createGroup/createGroupDate.njk
+++ b/server/views/createGroup/createGroupDate.njk
@@ -15,9 +15,6 @@
                   <div class="govuk-grid-column-two-thirds">
                     {{ govukBackLink(backLinkArgs) }}
                   </div>
-                  <div class="govuk-grid-column-one-third">
-                    <a class="return_to_homepage__link" href={{ homePageLink.href }}>{{ homePageLink.text }}</a>
-                  </div>
                 </div>
                 <div class="govuk-grid-row">
                     <div class="govuk-grid-column-two-thirds">

--- a/server/views/createGroup/createGroupLocation.njk
+++ b/server/views/createGroup/createGroupLocation.njk
@@ -16,9 +16,6 @@
       <div class="govuk-grid-column-two-thirds">
         {{ govukBackLink(backLinkArgs) }}
       </div>
-      <div class="govuk-grid-column-one-third">
-        <a class="return_to_homepage__link" href={{ homePageLink.href }}>{{ homePageLink.text }}</a>
-      </div>
     </div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/server/views/createGroup/createGroupPdu.njk
+++ b/server/views/createGroup/createGroupPdu.njk
@@ -15,9 +15,6 @@
       <div class="govuk-grid-column-two-thirds">
         {{ govukBackLink(backLinkArgs) }}
       </div>
-      <div class="govuk-grid-column-one-third">
-        <a class="return_to_homepage__link" href={{ homePageLink.href }}>{{ homePageLink.text }}</a>
-      </div>
     </div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/server/views/createGroup/createGroupSex.njk
+++ b/server/views/createGroup/createGroupSex.njk
@@ -15,9 +15,6 @@
                   <div class="govuk-grid-column-two-thirds">
                     {{ govukBackLink(backLinkArgs) }}
                   </div>
-                  <div class="govuk-grid-column-one-third">
-                    <a class="return_to_homepage__link" href={{ homePageLink.href }}>{{ homePageLink.text }}</a>
-                  </div>
                 </div>
                 <div class="govuk-grid-row">
                     <div class="govuk-grid-column-two-thirds">

--- a/server/views/createGroup/createGroupStart.njk
+++ b/server/views/createGroup/createGroupStart.njk
@@ -13,9 +13,6 @@
                 <div class="govuk-grid-column-two-thirds">
                   {{ govukBackLink(backLinkArgs) }}
                 </div>
-                <div class="govuk-grid-column-one-third">
-                  <a class="return_to_homepage__link" href={{ homePageLink.href }}>{{ homePageLink.text }}</a>
-                </div>
               </div>
               <div class="govuk-grid-row">
                   <div class="govuk-grid-column-two-thirds">

--- a/server/views/createGroup/createGroupTreatmentManager.njk
+++ b/server/views/createGroup/createGroupTreatmentManager.njk
@@ -196,9 +196,6 @@
       <div class="govuk-grid-column-two-thirds">
         {{ govukBackLink(backLinkArgs) }}
       </div>
-      <div class="govuk-grid-column-one-third">
-        <a class="return_to_homepage__link" href={{ homePageLink.href }}>{{ homePageLink.text }}</a>
-      </div>
     </div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/server/views/createGroup/createGroupWhen.njk
+++ b/server/views/createGroup/createGroupWhen.njk
@@ -18,11 +18,6 @@
           <div class="govuk-grid-column-two-thirds">
             {{ govukBackLink(backLinkArgs) }}
           </div>
-          <div class="govuk-grid-column-one-third">
-            <a class="return_to_homepage__link" href="{{ homePageLink.href }}">
-              {{ homePageLink.text }}
-            </a>
-          </div>
         </div>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
This PR is to remove the 'Go to Accredited Programmes homepage' link from all the 'edit group' pages. 

e.g. https://accredited-programmes-manage-and-deliver-dev.hmpps.service.justice.gov.uk/group/919d9bd6-49f9-4456-886b-3192c6000f1f/edit-a-group/edit-group-code

Also, to change 'Treatment manager' on this page below so that it is not a heading:

https://accredited-programmes-manage-and-deliver-dev.hmpps.service.justice.gov.uk/group/919d9bd6-49f9-4456-886b-3192c6000f1f/edit-group-facilitators