### PR TITLE
APG-2049 Update record attendance from session title to module title

### DIFF
--- a/server/@types/manageAndDeliverApi/imported/index.d.ts
+++ b/server/@types/manageAndDeliverApi/imported/index.d.ts
@@ -352,22 +352,6 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  '/dev/seed/referrals': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    post: operations['seedReferrals']
-    delete: operations['dangerouslyDeleteAllReferrals']
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
   '/admin/populate-personal-details': {
     parameters: {
       query?: never
@@ -846,22 +830,6 @@ export interface paths {
      * @description Get group by GroupCode and in User region
      */
     get: operations['getGroupInUserRegion']
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/dev/seed/health': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get: operations['health']
     put?: never
     post?: never
     delete?: never
@@ -2039,17 +2007,6 @@ export interface components {
        */
       message: string
     }
-    SeededReferralInfo: {
-      referralId: string
-      crn: string
-      personName: string
-      requirementId: string
-    }
-    SeedingResult: {
-      /** Format: int32 */
-      count: number
-      referrals: components['schemas']['SeededReferralInfo'][]
-    }
     CreateAvailability: {
       /**
        * Format: uuid
@@ -2108,6 +2065,14 @@ export interface components {
       filesize: number
       /** @description The filename of attachment file */
       filename: string
+      /** @description The additional headers to use when calling the url for fetching this attachment */
+      headers?: components['schemas']['AttachmentHeader'][] | null
+    }
+    AttachmentHeader: {
+      /** @description The name of the header */
+      name: string
+      /** @description The value of the header */
+      value: string
     }
     HmppsSubjectAccessRequestContent: {
       /** @description The content of the subject access request response */
@@ -3145,24 +3110,24 @@ export interface components {
       content?: components['schemas']['ReferralCaseListItem'][]
       /** Format: int32 */
       number?: number
+      sort?: components['schemas']['SortObject']
       first?: boolean
       last?: boolean
-      sort?: components['schemas']['SortObject']
-      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
+      pageable?: components['schemas']['PageableObject']
       empty?: boolean
     }
     PageableObject: {
       /** Format: int64 */
       offset?: number
       sort?: components['schemas']['SortObject']
-      /** Format: int32 */
-      pageNumber?: number
-      paged?: boolean
+      unpaged?: boolean
       /** Format: int32 */
       pageSize?: number
-      unpaged?: boolean
+      paged?: boolean
+      /** Format: int32 */
+      pageNumber?: number
     }
     ReferralCaseListItem: {
       /** Format: uuid */
@@ -3185,8 +3150,8 @@ export interface components {
     }
     SortObject: {
       empty?: boolean
-      sorted?: boolean
       unsorted?: boolean
+      sorted?: boolean
     }
     StatusFilterValues: {
       /**
@@ -3473,10 +3438,15 @@ export interface components {
     /** @description Details of a Record Attendance */
     RecordSessionAttendance: {
       /**
-       * @description A title of a session
-       * @example Getting started 1
+       * @description The name of the session
+       * @example Introduction to Building Choices
        */
       sessionTitle: string
+      /**
+       * @description The name of the module
+       * @example Getting started 1
+       */
+      sessionModule: string
       /**
        * @description Region name of a programme group
        * @example North East
@@ -3804,12 +3774,12 @@ export interface components {
       content?: components['schemas']['Group'][]
       /** Format: int32 */
       number?: number
+      sort?: components['schemas']['SortObject']
       first?: boolean
       last?: boolean
-      sort?: components['schemas']['SortObject']
-      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
+      pageable?: components['schemas']['PageableObject']
       empty?: boolean
     }
     GroupItem: {
@@ -3899,12 +3869,12 @@ export interface components {
       content?: components['schemas']['GroupItem'][]
       /** Format: int32 */
       number?: number
+      sort?: components['schemas']['SortObject']
       first?: boolean
       last?: boolean
-      sort?: components['schemas']['SortObject']
-      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
+      pageable?: components['schemas']['PageableObject']
       empty?: boolean
     }
     /** @description Details of a Programme Group including filters and paginated group data. */
@@ -5590,66 +5560,6 @@ export interface operations {
       }
     }
   }
-  seedReferrals: {
-    parameters: {
-      query?: {
-        count?: number
-      }
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          '*/*': components['schemas']['SeedingResult']
-        }
-      }
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          '*/*': components['schemas']['ErrorResponse']
-        }
-      }
-    }
-  }
-  dangerouslyDeleteAllReferrals: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          '*/*': components['schemas']['TeardownResult']
-        }
-      }
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          '*/*': components['schemas']['ErrorResponse']
-        }
-      }
-    }
-  }
   populatePersonalDetails: {
     parameters: {
       query?: never
@@ -7110,37 +7020,6 @@ export interface operations {
       }
       /** @description Forbidden. The client is not authorised to retrieve group details. */
       403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          '*/*': components['schemas']['ErrorResponse']
-        }
-      }
-    }
-  }
-  health: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          '*/*': {
-            [key: string]: string
-          }
-        }
-      }
-      /** @description Bad Request */
-      400: {
         headers: {
           [name: string]: unknown
         }

--- a/server/attendance/attendanceController.test.ts
+++ b/server/attendance/attendanceController.test.ts
@@ -106,7 +106,7 @@ describe('showRecordAttendancePage', () => {
 
       app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
 
-      const bffData = recordSessionAttendanceFactory.build({ sessionTitle: 'Getting started 1' })
+      const bffData = recordSessionAttendanceFactory.build({ sessionModule: 'Getting started 1' })
       accreditedProgrammesManageAndDeliverService.getRecordAttendanceBffData.mockResolvedValue(bffData)
 
       await request(app)
@@ -155,7 +155,7 @@ describe('showRecordAttendancePage', () => {
         .expect(302)
         .expect(res => {
           expect(res.text).toContain(
-            `Redirecting to /group/111/session/6789/referral/referral1/${convertToUrlFriendlyKebabCase(bffData.sessionTitle)}-session-notes`,
+            `Redirecting to /group/111/session/6789/referral/referral1/${convertToUrlFriendlyKebabCase(bffData.sessionModule)}-session-notes`,
           )
         })
     })
@@ -183,7 +183,7 @@ describe('showRecordAttendancePage', () => {
         .expect(302)
         .expect(res => {
           expect(res.text).toContain(
-            `Redirecting to /group/111/session/6789/referral/referral1/${convertToUrlFriendlyKebabCase(bffData.sessionTitle)}-session-notes`,
+            `Redirecting to /group/111/session/6789/referral/referral1/${convertToUrlFriendlyKebabCase(bffData.sessionModule)}-session-notes`,
           )
         })
       expect(accreditedProgrammesManageAndDeliverService.getRecordAttendanceBffData).toHaveBeenCalledWith(
@@ -203,7 +203,7 @@ describe('showRecordAttendancePage', () => {
 
       app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
 
-      const bffData = recordSessionAttendanceFactory.build({ sessionTitle: 'Pre-group one-to-one' })
+      const bffData = recordSessionAttendanceFactory.build({ sessionModule: 'Pre-group one-to-one' })
       bffData.people = [
         {
           ...bffData.people[0],
@@ -243,7 +243,7 @@ describe('showRecordAttendancePage', () => {
 
       app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
 
-      const bffData = recordSessionAttendanceFactory.build({ sessionTitle: 'Getting started 1' })
+      const bffData = recordSessionAttendanceFactory.build({ sessionModule: 'Getting started 1' })
       accreditedProgrammesManageAndDeliverService.getRecordAttendanceBffData.mockResolvedValue(bffData)
 
       await request(app)
@@ -251,7 +251,7 @@ describe('showRecordAttendancePage', () => {
         .expect(302)
         .expect(res => {
           expect(res.text).toContain(
-            `Redirecting to /group/111/session/6789/referral/referral1/${convertToUrlFriendlyKebabCase(bffData.sessionTitle)}-session-notes`,
+            `Redirecting to /group/111/session/6789/referral/referral1/${convertToUrlFriendlyKebabCase(bffData.sessionModule)}-session-notes`,
           )
         })
     })
@@ -266,7 +266,7 @@ describe('showRecordAttendancePage', () => {
 
       app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
 
-      const bffData = recordSessionAttendanceFactory.build({ sessionTitle: 'Pre-group one-to-one' })
+      const bffData = recordSessionAttendanceFactory.build({ sessionModule: 'Pre-group one-to-one' })
       bffData.people = [
         {
           ...bffData.people[0],
@@ -302,7 +302,7 @@ describe('showRecordAttendancePage', () => {
 
       app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
 
-      const bffData = recordSessionAttendanceFactory.build({ sessionTitle: 'Pre-group one-to-one' })
+      const bffData = recordSessionAttendanceFactory.build({ sessionModule: 'Pre-group one-to-one' })
       bffData.people = [
         {
           ...bffData.people[0],
@@ -332,7 +332,7 @@ describe('showRecordAttendancePage', () => {
 
       app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
 
-      const bffData = recordSessionAttendanceFactory.build({ sessionTitle: 'Pre-group one-to-one' })
+      const bffData = recordSessionAttendanceFactory.build({ sessionModule: 'Pre-group one-to-one' })
       bffData.people = [
         {
           ...bffData.people[0],
@@ -364,7 +364,7 @@ describe('showRecordAttendancePage', () => {
 
       app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
 
-      const bffData = recordSessionAttendanceFactory.build({ sessionTitle: 'Pre-group one-to-one' })
+      const bffData = recordSessionAttendanceFactory.build({ sessionModule: 'Pre-group one-to-one' })
       accreditedProgrammesManageAndDeliverService.getRecordAttendanceBffData.mockResolvedValue(bffData)
 
       await request(app)
@@ -389,7 +389,7 @@ describe('showRecordAttendancePage', () => {
 
       app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
 
-      const bffData = recordSessionAttendanceFactory.build({ sessionTitle: 'Pre-group one-to-one' })
+      const bffData = recordSessionAttendanceFactory.build({ sessionModule: 'Pre-group one-to-one' })
       bffData.people = [
         {
           ...bffData.people[0],
@@ -423,7 +423,7 @@ describe('showRecordAttendancePage', () => {
 
       app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
 
-      const bffData = recordSessionAttendanceFactory.build({ sessionTitle: 'Pre-group one-to-one' })
+      const bffData = recordSessionAttendanceFactory.build({ sessionModule: 'Pre-group one-to-one' })
       bffData.people = [
         {
           ...bffData.people[0],
@@ -455,7 +455,7 @@ describe('showRecordAttendancePage', () => {
 
       app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
 
-      const bffData = recordSessionAttendanceFactory.build({ sessionTitle: 'Pre-group one-to-one' })
+      const bffData = recordSessionAttendanceFactory.build({ sessionModule: 'Pre-group one-to-one' })
       bffData.people = [
         {
           ...bffData.people[0],
@@ -491,7 +491,7 @@ describe('showRecordAttendancePage', () => {
 
       app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
 
-      const bffData = recordSessionAttendanceFactory.build({ sessionTitle: 'Getting started 1' })
+      const bffData = recordSessionAttendanceFactory.build({ sessionModule: 'Getting started 1' })
       bffData.people = [{ ...bffData.people[0], referralId: 'referral1', name: 'Alice Brown' }]
       accreditedProgrammesManageAndDeliverService.getRecordAttendanceBffData.mockResolvedValue(bffData)
 
@@ -519,7 +519,7 @@ describe('showRecordAttendancePage', () => {
 
       app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
 
-      const bffData = recordSessionAttendanceFactory.build({ sessionTitle: 'Getting started 1' })
+      const bffData = recordSessionAttendanceFactory.build({ sessionModule: 'Getting started 1' })
       bffData.people = [{ ...bffData.people[0], referralId: 'referral1', name: 'Alice Brown' }]
       accreditedProgrammesManageAndDeliverService.getRecordAttendanceBffData.mockResolvedValue(bffData)
       accreditedProgrammesManageAndDeliverService.createSessionAttendance.mockResolvedValue({
@@ -560,7 +560,7 @@ describe('showRecordAttendancePage', () => {
 
       app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
 
-      const bffData = recordSessionAttendanceFactory.build({ sessionTitle: 'Understanding myself' })
+      const bffData = recordSessionAttendanceFactory.build({ sessionModule: 'Understanding myself' })
       bffData.people = [
         {
           ...bffData.people[0],
@@ -604,7 +604,7 @@ describe('showRecordAttendancePage', () => {
 
       app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
 
-      const bffData = recordSessionAttendanceFactory.build({ sessionTitle: 'Getting started 1' })
+      const bffData = recordSessionAttendanceFactory.build({ sessionModule: 'Getting started 1' })
       bffData.people = [{ ...bffData.people[0], referralId: 'referral1', name: 'Alice Brown' }]
       accreditedProgrammesManageAndDeliverService.getRecordAttendanceBffData.mockResolvedValue(bffData)
       accreditedProgrammesManageAndDeliverService.createSessionAttendance.mockResolvedValue({
@@ -641,7 +641,7 @@ describe('showRecordAttendancePage', () => {
 
       app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
 
-      const bffData = recordSessionAttendanceFactory.build({ sessionTitle: 'Getting started 1' })
+      const bffData = recordSessionAttendanceFactory.build({ sessionModule: 'Getting started 1' })
       bffData.people = [
         { ...bffData.people[0], referralId: 'referral1', name: 'Sham Booth' },
         { ...bffData.people[1], referralId: 'referral2', name: 'Adrian Poole' },
@@ -682,7 +682,7 @@ describe('showRecordAttendancePage', () => {
 
       app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
 
-      const bffData = recordSessionAttendanceFactory.build({ sessionTitle: 'Getting started 1' })
+      const bffData = recordSessionAttendanceFactory.build({ sessionModule: 'Getting started 1' })
       bffData.people = [
         { ...bffData.people[0], referralId: 'referral1', name: 'Alice Brown', sessionNotes: 'Existing note' },
       ]
@@ -720,7 +720,7 @@ describe('showRecordAttendancePage', () => {
 
       app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
 
-      const bffData = recordSessionAttendanceFactory.build({ sessionTitle: 'Getting started 1' })
+      const bffData = recordSessionAttendanceFactory.build({ sessionModule: 'Getting started 1' })
       bffData.people = [
         { ...bffData.people[0], referralId: 'referral1', name: 'Alice Brown', sessionNotes: 'Existing note' },
       ]
@@ -761,7 +761,7 @@ describe('showRecordAttendancePage', () => {
 
       app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
 
-      const bffData = recordSessionAttendanceFactory.build({ sessionTitle: 'Getting started 1' })
+      const bffData = recordSessionAttendanceFactory.build({ sessionModule: 'Getting started 1' })
       bffData.people = [
         { ...bffData.people[0], referralId: 'referral1', name: 'Sham Booth' },
         { ...bffData.people[1], referralId: 'referral2', name: 'Adrian Poole' },
@@ -819,7 +819,7 @@ describe('showRecordAttendancePage', () => {
 
       app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
 
-      const bffData = recordSessionAttendanceFactory.build({ sessionTitle: 'Getting started 1' })
+      const bffData = recordSessionAttendanceFactory.build({ sessionModule: 'Getting started 1' })
       bffData.people = [
         { ...bffData.people[0], referralId: 'referral1', name: 'Alex River', sessionNotes: 'Existing note.' },
       ]

--- a/server/attendance/attendanceController.ts
+++ b/server/attendance/attendanceController.ts
@@ -51,8 +51,8 @@ export default class AttendanceController extends BaseController {
     )
 
     if (req.method === 'GET' && referralIdFromQuery) {
-      const sessionTitle = convertToUrlFriendlyKebabCase(recordAttendanceBffData.sessionTitle)
-      return res.redirect(this.notesPageUri(groupId, sessionId, referralIdFromQuery, sessionTitle))
+      const sessionModule = convertToUrlFriendlyKebabCase(recordAttendanceBffData.sessionModule)
+      return res.redirect(this.notesPageUri(groupId, sessionId, referralIdFromQuery, sessionModule))
     }
 
     const recordAttendanceDataWithSessionSelections: RecordSessionAttendance = {
@@ -96,8 +96,8 @@ export default class AttendanceController extends BaseController {
             sessionNotes: existingPerson?.sessionNotes ?? attendee.sessionNotes,
           }
         })
-        const sessionTitle = convertToUrlFriendlyKebabCase(recordAttendanceBffData.sessionTitle)
-        return res.redirect(this.notesPageUri(groupId, sessionId, referralIds[0], sessionTitle))
+        const sessionModule = convertToUrlFriendlyKebabCase(recordAttendanceBffData.sessionModule)
+        return res.redirect(this.notesPageUri(groupId, sessionId, referralIds[0], sessionModule))
       }
     }
 
@@ -131,7 +131,7 @@ export default class AttendanceController extends BaseController {
       referralIds,
     )
 
-    const theGroupTitle = convertToUrlFriendlyKebabCase(recordAttendanceBffData.sessionTitle)
+    const theGroupTitle = convertToUrlFriendlyKebabCase(recordAttendanceBffData.sessionModule)
 
     if (!groupTitle && req.method === 'GET') {
       return res.redirect(this.notesPageUri(groupId, sessionId, referralId, theGroupTitle))
@@ -232,7 +232,7 @@ export default class AttendanceController extends BaseController {
           return res.redirect(`/group/${groupId}/session/${sessionId}/edit-session?${redirectQuery}`)
         }
 
-        const sessionSlug = convertToUrlFriendlyKebabCase(recordAttendanceBffData.sessionTitle)
+        const sessionSlug = convertToUrlFriendlyKebabCase(recordAttendanceBffData.sessionModule)
         const sessionNotesQuery = new URLSearchParams({
           referralId,
           source: 'edit-session',

--- a/server/attendance/attendanceNotes/attendanceSessionNotesPresenter.ts
+++ b/server/attendance/attendanceNotes/attendanceSessionNotesPresenter.ts
@@ -43,7 +43,7 @@ export default class AttendanceSessionNotesPresenter {
   }
 
   get sessionTitle() {
-    return this.recordAttendanceBffData?.sessionTitle || ''
+    return this.recordAttendanceBffData?.sessionModule || ''
   }
 
   get personName() {

--- a/server/attendance/attendancePresenter.test.ts
+++ b/server/attendance/attendancePresenter.test.ts
@@ -9,7 +9,7 @@ describe('AttendancePresenter', () => {
         bffData.people = [bffData.people[0]]
         const presenter = new AttendancePresenter(bffData, 'backlink', null)
 
-        expect(presenter.text.pageHeading).toBe(`Did ${bffData.people[0].name} attend ${bffData.sessionTitle}?`)
+        expect(presenter.text.pageHeading).toBe(`Did ${bffData.people[0].name} attend ${bffData.sessionModule}?`)
       })
     })
     describe('multiple attendees', () => {
@@ -17,7 +17,7 @@ describe('AttendancePresenter', () => {
         const bffData = recordSessionAttendanceFactory.build()
         const presenter = new AttendancePresenter(bffData, 'backlink', null)
 
-        expect(presenter.text.pageHeading).toBe(`Record attendance for ${bffData.sessionTitle}?`)
+        expect(presenter.text.pageHeading).toBe(`Record attendance for ${bffData.sessionModule}`)
       })
     })
   })

--- a/server/attendance/attendancePresenter.ts
+++ b/server/attendance/attendancePresenter.ts
@@ -14,8 +14,8 @@ export default class AttendancePresenter {
     return {
       pageHeading:
         this.recordAttendanceBffData.people.length === 1
-          ? `Did ${this.recordAttendanceBffData.people[0].name} attend ${this.recordAttendanceBffData.sessionTitle}?`
-          : `Record attendance for ${this.recordAttendanceBffData.sessionTitle}?`,
+          ? `Did ${this.recordAttendanceBffData.people[0].name} attend ${this.recordAttendanceBffData.sessionModule}?`
+          : `Record attendance for ${this.recordAttendanceBffData.sessionModule}`,
       headingCaption: `Record attendance and progress`,
     }
   }

--- a/server/sessionNotes/sessionNotesController.test.ts
+++ b/server/sessionNotes/sessionNotesController.test.ts
@@ -98,7 +98,8 @@ describe('SessionNotesController', () => {
       })
 
       accreditedProgrammesManageAndDeliverService.getRecordAttendanceBffData.mockResolvedValue({
-        sessionTitle: 'Getting started 1',
+        sessionTitle: 'Introduction to Building Choices',
+        sessionModule: 'Getting started 1',
         groupRegionName: 'North East',
         people: [
           {
@@ -173,7 +174,8 @@ describe('SessionNotesController', () => {
       app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
 
       accreditedProgrammesManageAndDeliverService.getRecordAttendanceBffData.mockResolvedValue({
-        sessionTitle: 'Getting started 1',
+        sessionTitle: 'Introduction to Building Choices',
+        sessionModule: 'Getting started 1',
         groupRegionName: 'North East',
         people: [
           {
@@ -436,7 +438,8 @@ describe('SessionNotesController', () => {
       })
 
       accreditedProgrammesManageAndDeliverService.getRecordAttendanceBffData.mockResolvedValue({
-        sessionTitle: 'Getting started 1',
+        sessionTitle: 'Introduction to Building Choices',
+        sessionModule: 'Getting started 1',
         groupRegionName: 'North East',
         people: [
           {
@@ -498,7 +501,8 @@ describe('SessionNotesController', () => {
       })
 
       accreditedProgrammesManageAndDeliverService.getRecordAttendanceBffData.mockResolvedValue({
-        sessionTitle: 'Getting started 1',
+        sessionTitle: 'Introduction to Building Choices',
+        sessionModule: 'Getting started 1',
         groupRegionName: 'North East',
         people: [
           {

--- a/server/testutils/factories/recordSessionAttendanceFactory.ts
+++ b/server/testutils/factories/recordSessionAttendanceFactory.ts
@@ -50,7 +50,8 @@ export default RecordSessionAttendanceFactory.define(({ sequence }) => {
   ]
 
   return {
-    sessionTitle: `Getting started ${sequence}`,
+    sessionTitle: `Introduction to Building Choices ${sequence}`,
+    sessionModule: `Getting started ${sequence}`,
     groupRegionName: 'North East',
     people,
   }


### PR DESCRIPTION
APG-2049

Currently, the session title (e.g. Introduction to Building choices )was being used instead of the module title (e.g. Getting started 1)in the record session inc. notes



**For multiples:**
h1 in dev reads "Record attendance for Introduction to Building Choices?"

It should read "Record attendance for Getting started 1" (alt session name, no question mark at the end)

Figma Multiple:https://www.figma.com/design/Y1h09XHyEI9O8KZoOpvlTS/Accredited-Programmes--Community-?node-id=11616-59646&t=38fNi7RZaWxCPZHz-0

**For single:**
h1 in dev reads "Colin Maggio-Schimmel: Introduction to Building Choices session notes"

It should read "Colin Maggio-Schimmel: Getting started 1 session notes" (alt session name)

Figma single: https://www.figma.com/design/Y1h09XHyEI9O8KZoOpvlTS/Accredited-Programmes--Community-?node-id=11616-59002&t=38fNi7RZaWxCPZHz-1


**Before Multiple**

<img width="946" height="833" alt="Screenshot 2026-05-05 at 14 46 50" src="https://github.com/user-attachments/assets/4805d665-67bc-4965-b334-7ead0860afe9" />


**After Multiple**

<img width="946" height="833" alt="Screenshot 2026-05-05 at 14 40 55" src="https://github.com/user-attachments/assets/ccd98456-e878-43a5-987f-a3eeb5511468" />


**Before single:**

<img width="946" height="833" alt="Screenshot 2026-05-05 at 14 42 38" src="https://github.com/user-attachments/assets/017be92e-ba97-4f94-8ba0-9f2b6293399b" />


**After single:**

<img width="946" height="833" alt="Screenshot 2026-05-05 at 14 41 05" src="https://github.com/user-attachments/assets/fe41cc58-ba92-4dee-8fac-6ef53362155e" />


**Session notes before:**

<img width="946" height="833" alt="Screenshot 2026-05-05 at 14 58 06" src="https://github.com/user-attachments/assets/aeda3a66-bb64-4650-9f23-f49175c0f7e9" />


**Session notes after:**

<img width="946" height="833" alt="Screenshot 2026-05-05 at 14 56 43" src="https://github.com/user-attachments/assets/3ee402fb-0bc0-4e96-a076-a917c688e5fd" />


