### PR TITLE
Remove hardcoding of home link in header

### DIFF
--- a/server/shared/routes/layoutView.ts
+++ b/server/shared/routes/layoutView.ts
@@ -1,5 +1,6 @@
-import LayoutPresenter, { PrimaryNavigationTab } from './layoutPresenter'
+import config from '../../config'
 import ServiceUserBannerView from '../serviceUserBannerView'
+import LayoutPresenter, { PrimaryNavigationTab } from './layoutPresenter'
 
 export interface PageContentView {
   renderArgs: [string, Record<string, unknown>]
@@ -54,6 +55,7 @@ export default class LayoutView {
         ...this.content.renderArgs[1],
         ...(this.serviceUserBannerView?.locals ?? {}),
         primaryNavigationArgs: this.primaryNavigationArgs,
+        authUrl: config.apis.hmppsAuth.url,
       },
     ]
   }

--- a/server/views/partials/header.njk
+++ b/server/views/partials/header.njk
@@ -10,7 +10,7 @@
           <image href="/assets/images/crest.svg" width="40" height="40" />
         </svg>
       </a>
-       <a class="hmpps-header__link hmpps-header__title__organisation-name" href="https://sign-in.hmpps.service.justice.gov.uk/auth/sign-in">HMPPS</a>
+       <a class="hmpps-header__link hmpps-header__title__organisation-name" href="{{ authUrl }}">HMPPS</a>
       <a class="hmpps-header__link hmpps-header__title__service-name govuk-!-padding-right-1" href="/">{{ applicationName }}</a>
 
       {% if environmentName %}


### PR DESCRIPTION
The banner hmpps link was always pointing to the Prod url. This PR reads the URL from the env variables of the env it's in and sets the url accordingly.