### PR TITLE
Apg 2179/catch ups played back incorrectly in sessions and attendance

### DIFF
--- a/server/@types/manageAndDeliverApi/imported/index.d.ts
+++ b/server/@types/manageAndDeliverApi/imported/index.d.ts
@@ -3110,24 +3110,24 @@ export interface components {
       content?: components['schemas']['ReferralCaseListItem'][]
       /** Format: int32 */
       number?: number
-      sort?: components['schemas']['SortObject']
       first?: boolean
       last?: boolean
+      sort?: components['schemas']['SortObject']
+      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
-      pageable?: components['schemas']['PageableObject']
       empty?: boolean
     }
     PageableObject: {
       /** Format: int64 */
       offset?: number
       sort?: components['schemas']['SortObject']
-      unpaged?: boolean
       /** Format: int32 */
       pageSize?: number
-      paged?: boolean
       /** Format: int32 */
       pageNumber?: number
+      paged?: boolean
+      unpaged?: boolean
     }
     ReferralCaseListItem: {
       /** Format: uuid */
@@ -3150,8 +3150,8 @@ export interface components {
     }
     SortObject: {
       empty?: boolean
-      unsorted?: boolean
       sorted?: boolean
+      unsorted?: boolean
     }
     StatusFilterValues: {
       /**
@@ -3774,12 +3774,12 @@ export interface components {
       content?: components['schemas']['Group'][]
       /** Format: int32 */
       number?: number
-      sort?: components['schemas']['SortObject']
       first?: boolean
       last?: boolean
+      sort?: components['schemas']['SortObject']
+      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
-      pageable?: components['schemas']['PageableObject']
       empty?: boolean
     }
     GroupItem: {
@@ -3869,12 +3869,12 @@ export interface components {
       content?: components['schemas']['GroupItem'][]
       /** Format: int32 */
       number?: number
-      sort?: components['schemas']['SortObject']
       first?: boolean
       last?: boolean
+      sort?: components['schemas']['SortObject']
+      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
-      pageable?: components['schemas']['PageableObject']
       empty?: boolean
     }
     /** @description Details of a Programme Group including filters and paginated group data. */
@@ -3986,6 +3986,11 @@ export interface components {
        * @example one-to-one
        */
       type: string
+      /**
+       * @description Whether the session is a catch-up session
+       * @example false
+       */
+      isCatchup: boolean
       /**
        * Format: date
        * @description The date of the session

--- a/server/editSession/editSessionPresenter.test.ts
+++ b/server/editSession/editSessionPresenter.test.ts
@@ -429,6 +429,43 @@ describe('EditSessionPresenter', () => {
     })
   })
 
+  describe('sessionTypeLabel', () => {
+    const buildSessionDetails = (overrides: Partial<GroupSessionResponse> = {}): GroupSessionResponse => ({
+      pageTitle: 'Session 1',
+      code: 'CODE-123',
+      sessionType: 'Group',
+      isCatchup: false,
+      attendanceAndSessionNotes: [],
+      date: '01 Feb 2026',
+      time: '1:00pm',
+      scheduledToAttend: [],
+      facilitators: [],
+      ...overrides,
+    })
+
+    it('returns Catch-up when the session is a catch-up', () => {
+      const presenter = new EditSessionPresenter(
+        mockGroupId,
+        buildSessionDetails({ sessionType: 'Group', isCatchup: true }),
+        mockSessionId,
+        mockDeleteUrl,
+      )
+
+      expect(presenter.sessionTypeLabel).toBe('Catch-up')
+    })
+
+    it('returns the raw session type when the session is not a catch-up', () => {
+      const presenter = new EditSessionPresenter(
+        mockGroupId,
+        buildSessionDetails({ sessionType: 'Group', isCatchup: false }),
+        mockSessionId,
+        mockDeleteUrl,
+      )
+
+      expect(presenter.sessionTypeLabel).toBe('Group')
+    })
+  })
+
   describe('canBeDeleted', () => {
     beforeEach(() => {
       jest.useFakeTimers()

--- a/server/editSession/editSessionPresenter.test.ts
+++ b/server/editSession/editSessionPresenter.test.ts
@@ -429,7 +429,7 @@ describe('EditSessionPresenter', () => {
     })
   })
 
-  describe('sessionTypeLabel', () => {
+  describe('sessionType', () => {
     const buildSessionDetails = (overrides: Partial<GroupSessionResponse> = {}): GroupSessionResponse => ({
       pageTitle: 'Session 1',
       code: 'CODE-123',
@@ -451,7 +451,7 @@ describe('EditSessionPresenter', () => {
         mockDeleteUrl,
       )
 
-      expect(presenter.sessionTypeLabel).toBe('Catch-up')
+      expect(presenter.sessionType).toBe('Catch-up')
     })
 
     it('returns the raw session type when the session is not a catch-up', () => {
@@ -462,7 +462,7 @@ describe('EditSessionPresenter', () => {
         mockDeleteUrl,
       )
 
-      expect(presenter.sessionTypeLabel).toBe('Group')
+      expect(presenter.sessionType).toBe('Group')
     })
   })
 

--- a/server/editSession/editSessionPresenter.ts
+++ b/server/editSession/editSessionPresenter.ts
@@ -109,7 +109,7 @@ export default class EditSessionPresenter {
     return this.sessionDetails.attendanceAndSessionNotes?.length > 0
   }
 
-  get sessionTypeLabel() {
+  get sessionType() {
     return this.sessionDetails.isCatchup ? 'Catch-up' : this.sessionDetails.sessionType
   }
 

--- a/server/editSession/editSessionPresenter.ts
+++ b/server/editSession/editSessionPresenter.ts
@@ -109,6 +109,10 @@ export default class EditSessionPresenter {
     return this.sessionDetails.attendanceAndSessionNotes?.length > 0
   }
 
+  get sessionTypeLabel() {
+    return this.sessionDetails.isCatchup ? 'Catch-up' : this.sessionDetails.sessionType
+  }
+
   attendanceOptionText(attendance: string | undefined) {
     return attendanceOptionText(attendance, attendanceOptionTextTags.editSession)
   }

--- a/server/editSession/editSessionView.ts
+++ b/server/editSession/editSessionView.ts
@@ -14,7 +14,7 @@ export default class EditSessionView {
             text: 'Session type',
           },
           value: {
-            text: sessionDetailsObj.sessionType,
+            text: this.presenter.sessionTypeLabel,
           },
         },
         {

--- a/server/editSession/editSessionView.ts
+++ b/server/editSession/editSessionView.ts
@@ -14,7 +14,7 @@ export default class EditSessionView {
             text: 'Session type',
           },
           value: {
-            text: this.presenter.sessionTypeLabel,
+            text: this.presenter.sessionType,
           },
         },
         {

--- a/server/sessionSchedule/sessionAttendance/sessionScheduleAttendancePresenter.test.ts
+++ b/server/sessionSchedule/sessionAttendance/sessionScheduleAttendancePresenter.test.ts
@@ -23,6 +23,7 @@ describe('SessionScheduleAttendancePresenter', () => {
             name: 'Session 1: Introduction',
             number: 1,
             type: 'One-to-one',
+            isCatchup: false,
             participants: ['John Doe', 'Jane Smith'],
             dateOfSession: '15 March 2025',
             timeOfSession: '9:30am to 11:00am',
@@ -33,6 +34,7 @@ describe('SessionScheduleAttendancePresenter', () => {
             name: 'Session 2: Progress check',
             number: 2,
             type: 'Group',
+            isCatchup: false,
             participants: ['John Doe'],
             dateOfSession: '22 March 2025',
             timeOfSession: '2:00pm to 3:30pm',
@@ -129,6 +131,47 @@ describe('SessionScheduleAttendancePresenter', () => {
       )
     })
 
+    it('shows the original session type when catch-up is false', () => {
+      const presenter = new SessionScheduleAttendancePresenter(groupId, mockGroupSessionsData)
+      const accordionItems = presenter.getAccordionItems()
+      const firstModuleContent = accordionItems[0].content.html
+
+      expect(firstModuleContent).toContain('One-to-one')
+      expect(firstModuleContent).toContain('Group')
+      expect(firstModuleContent).not.toContain('Catch-up')
+    })
+
+    it('shows Catch-up when isCatchup is true', () => {
+      const dataWithCatchupSessions = {
+        ...mockGroupSessionsData,
+        modules: [
+          {
+            ...mockGroupSessionsData.modules![0],
+            sessions: [
+              {
+                ...mockGroupSessionsData.modules![0].sessions![0],
+                type: 'Individual',
+                isCatchup: true,
+              },
+              {
+                ...mockGroupSessionsData.modules![0].sessions![1],
+                type: 'Group',
+                isCatchup: true,
+              },
+            ],
+          },
+        ],
+      }
+
+      const presenter = new SessionScheduleAttendancePresenter(groupId, dataWithCatchupSessions)
+      const accordionItems = presenter.getAccordionItems()
+      const content = accordionItems[0].content.html
+
+      expect(content.match(/Catch-up/g)).toHaveLength(2)
+      expect(content).not.toContain('<td class="govuk-table__cell">Individual</td>')
+      expect(content).not.toContain('<td class="govuk-table__cell">Group</td>')
+    })
+
     it('renders facilitators with spacing using govuk utility classes', () => {
       const presenter = new SessionScheduleAttendancePresenter(groupId, mockGroupSessionsData)
       const accordionItems = presenter.getAccordionItems()
@@ -179,6 +222,7 @@ describe('SessionScheduleAttendancePresenter', () => {
                 number: 1,
                 name: 'Bringing it all together 1: Future me plan',
                 type: 'Group',
+                isCatchup: false,
                 dateOfSession: 'Thursday 8 August 2126',
                 timeOfSession: '1pm to 3:30pm',
                 participants: ['All'],
@@ -333,6 +377,7 @@ describe('SessionScheduleAttendancePresenter', () => {
                 name: 'Session 3',
                 number: 1,
                 type: 'Group',
+                isCatchup: false,
                 participants: [] as string[],
                 dateOfSession: '1 April 2025',
                 timeOfSession: '10:00am to 11:30am',
@@ -492,6 +537,7 @@ describe('SessionScheduleAttendancePresenter', () => {
                 number: 1,
                 name: undefined as unknown as string,
                 type: undefined as unknown as string,
+                isCatchup: false,
                 participants: undefined as unknown as string[],
                 dateOfSession: undefined as unknown as string,
                 timeOfSession: undefined as unknown as string,
@@ -610,6 +656,7 @@ describe('SessionScheduleAttendancePresenter', () => {
                 number: 1,
                 name: 'Session 1: Advanced Techniques',
                 type: 'Workshop',
+                isCatchup: false,
                 participants: ['John Doe', 'Jane Smith', 'Bob Brown'],
                 dateOfSession: '1 June 2025',
                 timeOfSession: '10:00am to 12:00pm',
@@ -675,6 +722,7 @@ describe('SessionScheduleAttendancePresenter', () => {
                 number: 1,
                 name: 'Session 1: Written Assessment',
                 type: 'Assessment',
+                isCatchup: false,
                 participants: ['John Doe'],
                 dateOfSession: '15 June 2025',
                 timeOfSession: '9:00am to 10:00am',
@@ -685,6 +733,7 @@ describe('SessionScheduleAttendancePresenter', () => {
                 number: 2,
                 name: 'Session 2: Practical Assessment',
                 type: 'Assessment',
+                isCatchup: false,
                 participants: ['John Doe'],
                 dateOfSession: '22 June 2025',
                 timeOfSession: '2:00pm to 3:30pm',

--- a/server/sessionSchedule/sessionAttendance/sessionScheduleAttendancePresenter.ts
+++ b/server/sessionSchedule/sessionAttendance/sessionScheduleAttendancePresenter.ts
@@ -29,6 +29,10 @@ export default class SessionScheduleAttendancePresenter extends GroupServiceLayo
     }
   }
 
+  isCatchupSession(session: ProgrammeGroupModuleSessionsResponseGroupSession): boolean {
+    return session.isCatchup || session.type?.toUpperCase() === 'CATCH_UP'
+  }
+
   get scheduleSessionSuccessMessageArgs(): MojAlertComponentArgs | null {
     if (!this.successMessage) return null
 
@@ -130,11 +134,11 @@ export default class SessionScheduleAttendancePresenter extends GroupServiceLayo
       ? session.facilitators.join('<span class="govuk-!-display-block govuk-!-margin-bottom-1"></span>')
       : ''
     const dateSortValue = this.sortableTableDate(session.dateOfSession)
-
+    console.log(session)
     return `
     <tr class="govuk-table__row">
       <td class="govuk-table__cell"><a href="/group/${this.groupId}/session/${session.id}/edit-session">${session.name || ''}</a></td>
-      <td class="govuk-table__cell">${session.type || ''}</td>
+      <td class="govuk-table__cell">${this.isCatchupSession(session) ? 'Catch-up' : session.type || ''}</td>
       <td class="govuk-table__cell">${participants}</td>
       <td class="govuk-table__cell" data-sort-value="${dateSortValue}">${session.dateOfSession || ''}</td>
       <td class="govuk-table__cell">${session.timeOfSession || ''}</td>

--- a/server/sessionSchedule/sessionAttendance/sessionScheduleAttendancePresenter.ts
+++ b/server/sessionSchedule/sessionAttendance/sessionScheduleAttendancePresenter.ts
@@ -30,7 +30,7 @@ export default class SessionScheduleAttendancePresenter extends GroupServiceLayo
   }
 
   isCatchupSession(session: ProgrammeGroupModuleSessionsResponseGroupSession): boolean {
-    return session.isCatchup || session.type?.toUpperCase() === 'CATCH_UP'
+    return session.isCatchup ?? false
   }
 
   get scheduleSessionSuccessMessageArgs(): MojAlertComponentArgs | null {
@@ -134,7 +134,7 @@ export default class SessionScheduleAttendancePresenter extends GroupServiceLayo
       ? session.facilitators.join('<span class="govuk-!-display-block govuk-!-margin-bottom-1"></span>')
       : ''
     const dateSortValue = this.sortableTableDate(session.dateOfSession)
-    console.log(session)
+
     return `
     <tr class="govuk-table__row">
       <td class="govuk-table__cell"><a href="/group/${this.groupId}/session/${session.id}/edit-session">${session.name || ''}</a></td>


### PR DESCRIPTION
Catch-up should show under 'Session type' if it is a catch-up session.

After:

<img width="1430" height="708" alt="Screenshot 2026-05-06 at 16 07 29" src="https://github.com/user-attachments/assets/821d9e10-054a-49c4-a5be-2f2db2298b84" />


Before:

<img width="1430" height="708" alt="Screenshot 2026-05-06 at 16 08 07" src="https://github.com/user-attachments/assets/4a09ab88-5f34-494d-9945-1a8783c2db3d" />




After:

<img width="1430" height="708" alt="Screenshot 2026-05-06 at 16 09 47" src="https://github.com/user-attachments/assets/e6600860-12c1-47d4-b908-4a0a5e655906" />


Before:
<img width="1064" height="689" alt="Screenshot 2026-05-06 at 16 10 31" src="https://github.com/user-attachments/assets/9ba2000c-b675-4163-be2f-6b484cc440e2" />

