### PR TITLE
APG-2088-text updates

### DIFF
--- a/server/cohort/changeCohortView.ts
+++ b/server/cohort/changeCohortView.ts
@@ -20,7 +20,7 @@ export default class ChangeCohortView {
 
   get currentCohortText(): InsetTextArgs {
     return {
-      html: `<p> ${this.presenter.details.personName}'s, current cohort: </p>
+      html: `<p> ${this.presenter.details.personName}'s current cohort: </p>
         <p class="govuk-!-font-weight-bold">${formatCohort(this.presenter.details.cohort)}</p>`,
 
       classes: 'govuk-!-margin-top-0',
@@ -40,7 +40,7 @@ export default class ChangeCohortView {
       fieldset: {
         legend: {
           text: 'Select the new cohort',
-          isPageHeading: true,
+          isPageHeading: false,
           classes: 'govuk-fieldset__legend--m',
         },
       },

--- a/server/views/referralDetails/cohort/changeCohort.njk
+++ b/server/views/referralDetails/cohort/changeCohort.njk
@@ -14,7 +14,7 @@
         <div class="govuk-width-container">
             {{ govukBackLink(backLinkArgs) }}
             <main class="govuk-main-wrapper" id="main-content">
-                <h2 class="govuk-heading-l" data-testid="cohort-heading">Which cohort should {{presenter.details.personName}} be in?</h2>
+                <h1 class="govuk-heading-l" data-testid="cohort-heading">Which cohort should {{presenter.details.personName}} be in?</h1>
                 {{ govukInsetText(currentCohortText) }}
                 <form method="post" novalidate action="{{ presenter.changeCohortFormAction }}">
                     <input type="hidden" name="_csrf" value="{{csrfToken}}">


### PR DESCRIPTION
Comments from the ticket:

When changing the cohort via a PoP space, there is a screen ‘Which cohort should [Latoya Barton] be in?’
There is a content change on the page:
Remove the comma on the inset text playback: “Latoya Barton's, current cohort:” to “Latoya Barton's current cohort:”
There also isn’t an h1 on the page:
Change “Which cohort should [Latoya Barton] be in?” to be an h1, not an h2


**Changes**
1. comma removed from 'Colin Maggio-Schimmel's, current cohort:'
2. Which cohort should Colin Maggio-Schimmel be in? - changed to be an h1



Before

<img width="1064" height="689" alt="Screenshot 2026-05-07 at 10 06 22" src="https://github.com/user-attachments/assets/5b27b62d-3627-4b53-ba2f-7c704069d297" />




After

<img width="1064" height="689" alt="Screenshot 2026-05-07 at 10 09 11" src="https://github.com/user-attachments/assets/ac8db9d8-a340-4f91-9f52-5b6befc1bb9a" />

