### PR TITLE
Fix for create group captions

### DIFF
--- a/server/createGroup/cohort/createOrEditGroupCohortPresenter.test.ts
+++ b/server/createGroup/cohort/createOrEditGroupCohortPresenter.test.ts
@@ -1,5 +1,4 @@
 import { CreateGroupRequest } from '@manage-and-deliver-api'
-import { FormValidationError } from '../../utils/formValidationError'
 import CreateOrEditGroupCohortPresenter from './createOrEditGroupCohortPresenter'
 
 describe('CreateOrEditGroupCohortPresenter', () => {

--- a/server/createGroup/cohort/createOrEditGroupCohortPresenter.test.ts
+++ b/server/createGroup/cohort/createOrEditGroupCohortPresenter.test.ts
@@ -1,0 +1,95 @@
+import { CreateGroupRequest } from '@manage-and-deliver-api'
+import { FormValidationError } from '../../utils/formValidationError'
+import CreateOrEditGroupCohortPresenter from './createOrEditGroupCohortPresenter'
+
+describe('CreateOrEditGroupCohortPresenter', () => {
+  const groupId = '123456'
+  const groupCode = 'TestGroup1'
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('backLinkUri', () => {
+    it('returns correct back link when in edit journey', () => {
+      const presenter = new CreateOrEditGroupCohortPresenter(
+        null,
+        { groupCode: 'TestGroup1' },
+        null,
+        groupId,
+        groupCode,
+      )
+
+      expect(presenter.backLinkUri).toEqual('/group/123456/group-details')
+    })
+
+    it('returns correct back link when in create journey', () => {
+      const presenter = new CreateOrEditGroupCohortPresenter(null, { groupCode: 'TestGroup1' }, null, undefined)
+
+      expect(presenter.backLinkUri).toEqual('/group/create-a-group/group-days-and-times')
+    })
+  })
+
+  describe('captionText', () => {
+    it('returns edit caption when in edit journey', () => {
+      const presenter = new CreateOrEditGroupCohortPresenter(
+        null,
+        { groupCode: 'TestGroup1' },
+        null,
+        groupId,
+        groupCode,
+      )
+
+      expect(presenter.captionText).toEqual('Edit group TestGroup1')
+    })
+
+    it('returns create caption when in create journey', () => {
+      const createGroupFormData: Partial<CreateGroupRequest> = {
+        groupCode: 'NEW-GROUP-001',
+      }
+      const presenter = new CreateOrEditGroupCohortPresenter(null, createGroupFormData, null, undefined)
+
+      expect(presenter.captionText).toEqual('Create a group NEW-GROUP-001')
+    })
+  })
+
+  describe('pageTitle', () => {
+    it('returns edit page title when in edit journey', () => {
+      const presenter = new CreateOrEditGroupCohortPresenter(
+        null,
+        { groupCode: 'TestGroup1' },
+        null,
+        groupId,
+        groupCode,
+      )
+
+      expect(presenter.pageTitle).toEqual('Edit the group cohort')
+    })
+
+    it('returns create page title when in create journey', () => {
+      const presenter = new CreateOrEditGroupCohortPresenter(null, { groupCode: 'TestGroup1' }, null, undefined)
+
+      expect(presenter.pageTitle).toEqual('Create group cohort')
+    })
+  })
+
+  describe('submitButtonText', () => {
+    it('returns Submit when in edit journey', () => {
+      const presenter = new CreateOrEditGroupCohortPresenter(
+        null,
+        { groupCode: 'TestGroup1' },
+        null,
+        groupId,
+        groupCode,
+      )
+
+      expect(presenter.submitButtonText).toEqual('Submit')
+    })
+
+    it('returns Continue when in create journey', () => {
+      const presenter = new CreateOrEditGroupCohortPresenter(null, { groupCode: 'TestGroup1' }, null, undefined)
+
+      expect(presenter.submitButtonText).toEqual('Continue')
+    })
+  })
+})

--- a/server/createGroup/cohort/createOrEditGroupCohortPresenter.ts
+++ b/server/createGroup/cohort/createOrEditGroupCohortPresenter.ts
@@ -20,7 +20,7 @@ export default class CreateOrEditGroupCohortPresenter {
   }
 
   get captionText() {
-    return this.isEditJourney ? `Edit group ${this.groupCode}` : 'Create a group'
+    return this.isEditJourney ? `Edit group ${this.groupCode}` : `Create a group ${this.createGroupFormData.groupCode}`
   }
 
   get pageTitle() {

--- a/server/createGroup/sex/createOrEditGroupSexPresenter.test.ts
+++ b/server/createGroup/sex/createOrEditGroupSexPresenter.test.ts
@@ -1,0 +1,70 @@
+import { CreateGroupRequest } from '@manage-and-deliver-api'
+import CreateOrEditGroupSexPresenter from './createOrEditGroupSexPresenter'
+
+describe('CreateOrEditGroupSexPresenter', () => {
+  const groupId = '123456'
+  const groupCode = 'TestGroup1'
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('backLinkUri', () => {
+    it('returns correct back link when in edit journey', () => {
+      const presenter = new CreateOrEditGroupSexPresenter(null, { groupCode: 'TestGroup1' }, null, groupId, groupCode)
+
+      expect(presenter.backLinkUri).toEqual('/group/123456/group-details')
+    })
+
+    it('returns correct back link when in create journey', () => {
+      const presenter = new CreateOrEditGroupSexPresenter(null, { groupCode: 'TestGroup1' }, null, undefined)
+
+      expect(presenter.backLinkUri).toEqual('/group/create-a-group/group-cohort')
+    })
+  })
+
+  describe('captionText', () => {
+    it('returns edit caption when in edit journey', () => {
+      const presenter = new CreateOrEditGroupSexPresenter(null, { groupCode: 'TestGroup1' }, null, groupId, groupCode)
+
+      expect(presenter.captionText).toEqual('Edit group TestGroup1')
+    })
+
+    it('returns create caption when in create journey', () => {
+      const createGroupFormData: Partial<CreateGroupRequest> = {
+        groupCode: 'NEW-GROUP-001',
+      }
+      const presenter = new CreateOrEditGroupSexPresenter(null, createGroupFormData, null, undefined)
+
+      expect(presenter.captionText).toEqual('Create a group NEW-GROUP-001')
+    })
+  })
+
+  describe('pageTitle', () => {
+    it('returns edit page title when in edit journey', () => {
+      const presenter = new CreateOrEditGroupSexPresenter(null, { groupCode: 'TestGroup1' }, null, groupId, groupCode)
+
+      expect(presenter.pageTitle).toEqual('Edit the gender of the group')
+    })
+
+    it('returns create page title when in create journey', () => {
+      const presenter = new CreateOrEditGroupSexPresenter(null, { groupCode: 'TestGroup1' }, null, undefined)
+
+      expect(presenter.pageTitle).toEqual('Select the gender of the group')
+    })
+  })
+
+  describe('submitButtonText', () => {
+    it('returns Submit when in edit journey', () => {
+      const presenter = new CreateOrEditGroupSexPresenter(null, { groupCode: 'TestGroup1' }, null, groupId, groupCode)
+
+      expect(presenter.submitButtonText).toEqual('Submit')
+    })
+
+    it('returns Continue when in create journey', () => {
+      const presenter = new CreateOrEditGroupSexPresenter(null, { groupCode: 'TestGroup1' }, null, undefined)
+
+      expect(presenter.submitButtonText).toEqual('Continue')
+    })
+  })
+})

--- a/server/createGroup/sex/createOrEditGroupSexPresenter.ts
+++ b/server/createGroup/sex/createOrEditGroupSexPresenter.ts
@@ -20,7 +20,7 @@ export default class CreateOrEditGroupSexPresenter {
   }
 
   get captionText() {
-    return this.isEditJourney ? `Edit group ${this.groupCode}` : 'Create a group'
+    return this.isEditJourney ? `Edit group ${this.groupCode}` : `Create a group ${this.createGroupFormData.groupCode}`
   }
 
   get pageTitle() {


### PR DESCRIPTION
Fix to display the group code in the page caption when selecting cohort or sex in the create a group journey

<img width="1920" height="1049" alt="image" src="https://github.com/user-attachments/assets/37464f85-d75b-4892-b5cf-82064d988307" />

<img width="1920" height="1049" alt="image" src="https://github.com/user-attachments/assets/6648cac5-1c0f-41ad-be1a-df080f26af79" />

