### PR TITLE
table captions

### DIFF
--- a/server/availabilityAndMotivation/availability/availabilityPresenter.test.ts
+++ b/server/availabilityAndMotivation/availability/availabilityPresenter.test.ts
@@ -88,8 +88,6 @@ describe(`getAvailabilityTableArgs.`, () => {
     }
     const presenter = new AvailabilityPresenter(referralDetails, 'availability', availability)
     expect(presenter.getAvailabilityTableArgs()).toEqual({
-      caption: 'Availability schedule',
-      captionClasses: 'govuk-heading-s',
       firstCellIsHeader: true,
       head: [{ text: 'Day' }, { text: 'Daytime' }, { text: 'Evening' }, { text: 'Nighttime' }],
       rows: [

--- a/server/availabilityAndMotivation/availability/availabilityPresenter.test.ts
+++ b/server/availabilityAndMotivation/availability/availabilityPresenter.test.ts
@@ -171,7 +171,7 @@ describe('availabilityTableHeading', () => {
     const presenter = new AvailabilityPresenter(referralDetails, 'availability', availability)
     expect(presenter.availabilityTableHeading).toEqual({
       text: 'Availability schedule',
-      classes: 'govuk-heading-s govuk-table__caption--s',
+      classes: 'govuk-heading-s',
     })
   })
 })

--- a/server/availabilityAndMotivation/availability/availabilityPresenter.test.ts
+++ b/server/availabilityAndMotivation/availability/availabilityPresenter.test.ts
@@ -89,6 +89,7 @@ describe(`getAvailabilityTableArgs.`, () => {
     const presenter = new AvailabilityPresenter(referralDetails, 'availability', availability)
     expect(presenter.getAvailabilityTableArgs()).toEqual({
       caption: 'Availability schedule',
+      captionClasses: 'govuk-heading-s',
       firstCellIsHeader: true,
       head: [{ text: 'Day' }, { text: 'Daytime' }, { text: 'Evening' }, { text: 'Nighttime' }],
       rows: [

--- a/server/availabilityAndMotivation/availability/availabilityPresenter.test.ts
+++ b/server/availabilityAndMotivation/availability/availabilityPresenter.test.ts
@@ -88,6 +88,7 @@ describe(`getAvailabilityTableArgs.`, () => {
     }
     const presenter = new AvailabilityPresenter(referralDetails, 'availability', availability)
     expect(presenter.getAvailabilityTableArgs()).toEqual({
+      caption: 'Availability schedule',
       firstCellIsHeader: true,
       head: [{ text: 'Day' }, { text: 'Daytime' }, { text: 'Evening' }, { text: 'Nighttime' }],
       rows: [

--- a/server/availabilityAndMotivation/availability/availabilityPresenter.test.ts
+++ b/server/availabilityAndMotivation/availability/availabilityPresenter.test.ts
@@ -88,6 +88,8 @@ describe(`getAvailabilityTableArgs.`, () => {
     }
     const presenter = new AvailabilityPresenter(referralDetails, 'availability', availability)
     expect(presenter.getAvailabilityTableArgs()).toEqual({
+      caption: 'Availability schedule',
+      captionClasses: 'govuk-visually-hidden',
       firstCellIsHeader: true,
       head: [{ text: 'Day' }, { text: 'Daytime' }, { text: 'Evening' }, { text: 'Nighttime' }],
       rows: [

--- a/server/availabilityAndMotivation/availability/availabilityPresenter.test.ts
+++ b/server/availabilityAndMotivation/availability/availabilityPresenter.test.ts
@@ -137,3 +137,39 @@ describe(`getAvailabilityTableArgs.`, () => {
     })
   })
 })
+
+describe('availabilityTableHeading', () => {
+  it('should return the heading with correct text and classes', () => {
+    const referralDetails: ReferralDetails = {
+      id: '1234',
+      crn: '1234',
+      personName: 'Emma Smith',
+      interventionName: 'An Intervention',
+      createdAt: '2025-01-01',
+      dateOfBirth: '1990-02-02',
+      probationPractitionerName: 'Alex River',
+      probationPractitionerEmail: 'alex.river@justice.gov.uk',
+      cohort: 'GENERAL_OFFENCE',
+      hasLdc: true,
+      hasLdcDisplayText: 'May need an LDC-adapted programme',
+      currentStatusDescription: 'Awaiting assessment',
+      pdu: 'London',
+      reportingTeam: 'team A',
+    }
+    const availability: Availability = {
+      id: '533f391d-a4dd-4a3f-b53d-e8ff2ab5db86',
+      referralId: '39fde7e8-d2e3-472b-8364-5848bf673aa6',
+      startDate: '2025-07-30',
+      endDate: '2025-07-31',
+      otherDetails: 'some stuff',
+      lastModifiedBy: 'REFER_MONITOR_PP',
+      lastModifiedAt: '2025-07-30T07:50:40.581763',
+      availabilities: [],
+    }
+    const presenter = new AvailabilityPresenter(referralDetails, 'availability', availability)
+    expect(presenter.availabilityTableHeading).toEqual({
+      text: 'Availability schedule',
+      classes: 'govuk-heading-s govuk-table__caption--s',
+    })
+  })
+})

--- a/server/availabilityAndMotivation/availability/availabilityPresenter.ts
+++ b/server/availabilityAndMotivation/availability/availabilityPresenter.ts
@@ -49,6 +49,7 @@ export default class AvailabilityPresenter extends AvailabilityAndMotivationPres
 
     return {
       caption: 'Availability schedule',
+      captionClasses: 'govuk-heading-s',
       firstCellIsHeader: true,
       head: headings,
       rows,

--- a/server/availabilityAndMotivation/availability/availabilityPresenter.ts
+++ b/server/availabilityAndMotivation/availability/availabilityPresenter.ts
@@ -20,7 +20,7 @@ export default class AvailabilityPresenter extends AvailabilityAndMotivationPres
   get availabilityTableHeading() {
     return {
       text: 'Availability schedule',
-      classes: 'govuk-heading-s govuk-table__caption--s',
+      classes: 'govuk-heading-s',
     }
   }
 

--- a/server/availabilityAndMotivation/availability/availabilityPresenter.ts
+++ b/server/availabilityAndMotivation/availability/availabilityPresenter.ts
@@ -48,6 +48,7 @@ export default class AvailabilityPresenter extends AvailabilityAndMotivationPres
     })
 
     return {
+      caption: 'Availability schedule',
       firstCellIsHeader: true,
       head: headings,
       rows,

--- a/server/availabilityAndMotivation/availability/availabilityPresenter.ts
+++ b/server/availabilityAndMotivation/availability/availabilityPresenter.ts
@@ -17,6 +17,13 @@ export default class AvailabilityPresenter extends AvailabilityAndMotivationPres
     return this.availability.id !== null
   }
 
+  get availabilityTableHeading() {
+    return {
+      text: 'Availability schedule',
+      classes: 'govuk-heading-s govuk-table__caption--s',
+    }
+  }
+
   getAvailabilityTableArgs() {
     // Get all the possible headings out of the object e.g. daytime, evening
     const uniqueSlotLabels = [
@@ -48,8 +55,6 @@ export default class AvailabilityPresenter extends AvailabilityAndMotivationPres
     })
 
     return {
-      caption: 'Availability schedule',
-      captionClasses: 'govuk-heading-s',
       firstCellIsHeader: true,
       head: headings,
       rows,

--- a/server/availabilityAndMotivation/availability/availabilityPresenter.ts
+++ b/server/availabilityAndMotivation/availability/availabilityPresenter.ts
@@ -55,6 +55,8 @@ export default class AvailabilityPresenter extends AvailabilityAndMotivationPres
     })
 
     return {
+      caption: 'Availability schedule',
+      captionClasses: 'govuk-visually-hidden',
       firstCellIsHeader: true,
       head: headings,
       rows,

--- a/server/availabilityAndMotivation/availability/availabilityView.ts
+++ b/server/availabilityAndMotivation/availability/availabilityView.ts
@@ -47,6 +47,7 @@ export default class AvailabilityView {
         availabilityButtonArgs: this.availabilityButtonArgs,
         availability: this.presenter.availability,
         availabilityTableArgs: this.presenter.getAvailabilityTableArgs(),
+        availabilityTableHeading: this.presenter.availabilityTableHeading,
         showAvailability: this.presenter.showAvailability,
         isAvailabilityUpdated: this.presenter.isAvailabilityUpdated,
         successMessageArgs: this.successMessageArgs(),

--- a/server/caselist/caselistPresenter.test.ts
+++ b/server/caselist/caselistPresenter.test.ts
@@ -510,3 +510,82 @@ describe('generateTableRows', () => {
     expect(rows).toHaveLength(0)
   })
 })
+
+describe('tableCaptionClass', () => {
+  it('should return govuk-visually-hidden when there are no rows', () => {
+    const referralCaseListItemPage: Page<ReferralCaseListItem> = pageFactory
+      .pageContent([])
+      .build({ totalElements: 0, number: 0, size: 10, numberOfElements: 0 }) as Page<ReferralCaseListItem>
+    const presenter = new CaselistPresenter(
+      1,
+      referralCaseListItemPage,
+      {} as CaselistFilter,
+      '',
+      true,
+      TestUtils.createCaseListFilters(),
+      0,
+      'test location',
+    )
+
+    expect(presenter.tableCaptionClass).toBe('govuk-visually-hidden')
+  })
+
+  it('should return govuk-table__caption--m when rows exist', () => {
+    const referralCaseListItem = referralCaseListItemFactory.build()
+    const referralCaseListItemPage: Page<ReferralCaseListItem> = pageFactory
+      .pageContent([referralCaseListItem])
+      .build() as Page<ReferralCaseListItem>
+    const presenter = new CaselistPresenter(
+      1,
+      referralCaseListItemPage,
+      {} as CaselistFilter,
+      '',
+      true,
+      TestUtils.createCaseListFilters(),
+      0,
+      'test location',
+    )
+
+    expect(presenter.tableCaptionClass).toBe('govuk-table__caption--m')
+  })
+})
+
+describe('tableCaption', () => {
+  it('should return Open referrals for the open section', () => {
+    const referralCaseListItem = referralCaseListItemFactory.build()
+    const referralCaseListItemPage: Page<ReferralCaseListItem> = pageFactory
+      .pageContent([referralCaseListItem])
+      .build() as Page<ReferralCaseListItem>
+    const presenter = new CaselistPresenter(
+      1,
+      referralCaseListItemPage,
+      {} as CaselistFilter,
+      '',
+      true,
+      TestUtils.createCaseListFilters(),
+      0,
+      'test location',
+    )
+
+    expect(presenter.tableCaption).toBe('Open referrals')
+  })
+
+  it('should return Closed referrals for the closed section', () => {
+    const referralCaseListItem = referralCaseListItemFactory.build()
+    const referralCaseListItemPage: Page<ReferralCaseListItem> = pageFactory
+      .pageContent([referralCaseListItem])
+      .build() as Page<ReferralCaseListItem>
+    const presenter = new CaselistPresenter(
+      2,
+      referralCaseListItemPage,
+      {} as CaselistFilter,
+      '',
+      false,
+      TestUtils.createCaseListFilters(),
+      0,
+      'test location',
+    )
+
+    expect(presenter.tableCaption).toBe('Closed referrals')
+  })
+})

--- a/server/caselist/caselistPresenter.ts
+++ b/server/caselist/caselistPresenter.ts
@@ -65,8 +65,21 @@ export default class CaselistPresenter {
     return `Showing <strong>${start}</strong> to <strong>${end}</strong> of <strong>${totalElements}</strong> results`
   }
 
+  get tableCaptionClass(): string {
+    if (this.referralCaseListItems.content.length === 0) {
+      return 'govuk-visually-hidden'
+    }
+    return 'govuk-table__caption--m'
+  }
+
+  get tableCaption(): string {
+    return this.section === CaselistPageSection.Closed ? 'Closed referrals' : 'Open referrals'
+  }
+
   getCaseloadTableArgs(): TableArgs {
     return {
+      caption: this.tableCaption,
+      captionClasses: this.tableCaptionClass,
       attributes: {
         'data-module': 'moj-sortable-table',
       },

--- a/server/editSession/editSessionPresenter.test.ts
+++ b/server/editSession/editSessionPresenter.test.ts
@@ -43,6 +43,8 @@ describe('EditSessionPresenter', () => {
         expect(result).toEqual({
           idPrefix: 'attendance-multi-select',
           headers: [{ text: 'Name and CRN' }, { text: 'Attendance' }, { text: 'Session notes' }],
+          caption: 'Attendance record and session notes',
+          captionClasses: 'govuk-visually-hidden',
           rows: [
             {
               id: 'attendance-multi-select-row-0',
@@ -99,6 +101,8 @@ describe('EditSessionPresenter', () => {
 
         expect(result).toEqual({
           head: [{ text: 'Name and CRN' }, { text: 'Attendance' }, { text: 'Session notes' }],
+          caption: 'Attendance record and session notes',
+          captionClasses: 'govuk-visually-hidden',
           rows: [
             [
               { html: '<a href="/referral-details/123/personal-details">Alex River</a> CRN001' },
@@ -138,6 +142,8 @@ describe('EditSessionPresenter', () => {
 
         expect(result).toEqual({
           head: [{ text: 'Name and CRN' }, { text: 'Attendance' }, { text: 'Session notes' }],
+          caption: 'Attendance record and session notes',
+          captionClasses: 'govuk-visually-hidden',
           rows: [
             [
               { html: '<a href="/referral-details/123/personal-details">Alex River</a> CRN001' },
@@ -177,6 +183,8 @@ describe('EditSessionPresenter', () => {
 
         expect(result).toEqual({
           head: [{ text: 'Name and CRN' }, { text: 'Attendance' }, { text: 'Session notes' }],
+          caption: 'Attendance record and session notes',
+          captionClasses: 'govuk-visually-hidden',
           rows: [
             [
               { html: '<a href="/referral-details/123/personal-details">Alex River</a> CRN001' },
@@ -210,6 +218,8 @@ describe('EditSessionPresenter', () => {
 
         expect(result).toEqual({
           head: [{ text: 'Name and CRN' }, { text: 'Attendance' }, { text: 'Session notes' }],
+          caption: 'Attendance record and session notes',
+          captionClasses: 'govuk-visually-hidden',
           rows: [],
         })
       })
@@ -241,6 +251,8 @@ describe('EditSessionPresenter', () => {
 
         expect(result).toEqual({
           head: [{ text: 'Name and CRN' }, { text: 'Attendance' }, { text: 'Session notes' }],
+          caption: 'Attendance record and session notes',
+          captionClasses: 'govuk-visually-hidden',
           rows: [
             [
               { html: '<a href="/referral-details/123/personal-details">Alex River</a> CRN001' },
@@ -283,6 +295,8 @@ describe('EditSessionPresenter', () => {
 
         expect(result).toEqual({
           head: [{ text: 'Name and CRN' }, { text: 'Attendance' }, { text: 'Session notes' }],
+          caption: 'Attendance record and session notes',
+          captionClasses: 'govuk-visually-hidden',
           rows: [
             [
               { html: '<a href="/referral-details/123/personal-details">Alex River</a> CRN001' },
@@ -322,6 +336,8 @@ describe('EditSessionPresenter', () => {
 
         expect(result).toEqual({
           head: [{ text: 'Name and CRN' }, { text: 'Attendance' }, { text: 'Session notes' }],
+          caption: 'Attendance record and session notes',
+          captionClasses: 'govuk-visually-hidden',
           rows: [
             [
               { html: '<a href="/referral-details/123/personal-details">Alex River</a> CRN001' },
@@ -361,6 +377,8 @@ describe('EditSessionPresenter', () => {
 
         expect(result).toEqual({
           head: [{ text: 'Name and CRN' }, { text: 'Attendance' }, { text: 'Session notes' }],
+          caption: 'Attendance record and session notes',
+          captionClasses: 'govuk-visually-hidden',
           rows: [
             [
               { html: '<a href="/referral-details/123/personal-details">Alex River</a> CRN001' },

--- a/server/editSession/editSessionPresenter.ts
+++ b/server/editSession/editSessionPresenter.ts
@@ -116,6 +116,8 @@ export default class EditSessionPresenter {
     if (this.hasMultipleReferrals) {
       return {
         idPrefix: 'attendance-multi-select',
+        caption: 'Attendance record and session notes',
+        captionClasses: 'govuk-visually-hidden',
         headers,
         rows: attendanceData.map((it, index) => ({
           id: `attendance-multi-select-row-${index}`,
@@ -132,6 +134,8 @@ export default class EditSessionPresenter {
     }
     return {
       head: headers,
+      caption: 'Attendance record and session notes',
+      captionClasses: 'govuk-visually-hidden',
       rows:
         attendanceData.length > 0
           ? [
@@ -145,6 +149,14 @@ export default class EditSessionPresenter {
             ]
           : [],
     }
+  }
+
+  private get tableCaptionClass(): string {
+    const attendanceData = this.sessionDetails.attendanceAndSessionNotes || []
+    if (attendanceData.length === 0) {
+      return ''
+    }
+    return 'govuk-visually-hidden'
   }
 
   get attendanceHeading() {

--- a/server/editSession/editSessionPresenter.ts
+++ b/server/editSession/editSessionPresenter.ts
@@ -162,7 +162,7 @@ export default class EditSessionPresenter {
   get attendanceHeading() {
     return {
       text: 'Attendance and session notes',
-      classes: 'govuk-table__caption--m',
+      classes: 'govuk-heading-m',
     }
   }
 

--- a/server/editSession/editSessionPresenter.ts
+++ b/server/editSession/editSessionPresenter.ts
@@ -151,14 +151,6 @@ export default class EditSessionPresenter {
     }
   }
 
-  private get tableCaptionClass(): string {
-    const attendanceData = this.sessionDetails.attendanceAndSessionNotes || []
-    if (attendanceData.length === 0) {
-      return ''
-    }
-    return 'govuk-visually-hidden'
-  }
-
   get attendanceHeading() {
     return {
       text: 'Attendance and session notes',

--- a/server/editSession/editSessionPresenter.ts
+++ b/server/editSession/editSessionPresenter.ts
@@ -147,6 +147,13 @@ export default class EditSessionPresenter {
     }
   }
 
+  get attendanceHeading() {
+    return {
+      text: 'Attendance and session notes',
+      classes: 'govuk-table__caption--m',
+    }
+  }
+
   get fields() {
     return {
       'multi-select-selected': {

--- a/server/editSession/editSessionView.ts
+++ b/server/editSession/editSessionView.ts
@@ -148,6 +148,7 @@ export default class EditSessionView {
         hasMultipleReferrals: this.presenter.hasMultipleReferrals,
         hasReferral: this.presenter.hasReferral,
         singleReferral: this.singleReferral,
+        attendanceHeading: this.presenter.attendanceHeading,
       },
     ]
   }

--- a/server/group/groupPresenter.test.ts
+++ b/server/group/groupPresenter.test.ts
@@ -150,6 +150,8 @@ describe('groupTableArgs', () => {
       attributes: {
         'data-module': 'moj-sortable-table',
       },
+      caption: 'Not started or in progress groups',
+      captionClasses: 'govuk-table__caption--m',
       head: [
         {
           text: 'Group code',
@@ -204,6 +206,59 @@ describe('groupTableArgs', () => {
         ],
       ],
     })
+  })
+
+  it('should use the closed referrals caption for the completed tab', () => {
+    const groupList = groupsByRegionFactory.build()
+
+    const presenter = new GroupPresenter(
+      groupList.pagedGroupData as Page<Group>,
+      GroupListPageSection.COMPLETE,
+      groupList.otherTabTotal,
+      groupList.regionName,
+      GroupListFilter.empty(),
+      [],
+      [],
+    )
+
+    expect(presenter.groupTableArgs.caption).toBe('Completed groups')
+  })
+})
+
+describe('captionClasses', () => {
+  it('should return govuk-visually-hidden when there are no table rows', () => {
+    const filter = GroupListFilter.empty()
+    const pagedGroups: Page<Group> = pageFactory
+      .pageContent([])
+      .build({ totalElements: 0, number: 0, size: 10, numberOfElements: 0 }) as Page<Group>
+
+    const presenter = new GroupPresenter(
+      pagedGroups,
+      GroupListPageSection.NOT_STARTED_OR_IN_PROGRESS,
+      0,
+      'Region',
+      filter,
+      [],
+      [],
+      ['govuk-heading-m'],
+    )
+
+    expect(presenter.tableCaptionClass).toBe('govuk-visually-hidden')
+  })
+
+  it('should return govuk-table__caption--m when table rows exist', () => {
+    const groupList = groupsByRegionFactory.build()
+    const presenter = new GroupPresenter(
+      groupList.pagedGroupData as Page<Group>,
+      GroupListPageSection.NOT_STARTED_OR_IN_PROGRESS,
+      groupList.otherTabTotal,
+      groupList.regionName,
+      GroupListFilter.empty(),
+      [],
+      [],
+    )
+
+    expect(presenter.tableCaptionClass).toBe('govuk-table__caption--m')
   })
 })
 

--- a/server/group/groupPresenter.ts
+++ b/server/group/groupPresenter.ts
@@ -34,6 +34,7 @@ export default class GroupPresenter {
     readonly filter: GroupListFilter,
     readonly pduNames: string[],
     deliveryLocations?: string[],
+    readonly caption?: string[],
   ) {
     this.params = filter.paramsAsQueryParams
     this.groupListItems = groupListItems
@@ -49,8 +50,21 @@ export default class GroupPresenter {
     }
   }
 
+  get tableCaptionClass(): string {
+    if (this.groupListItems.content.length === 0) {
+      return 'govuk-visually-hidden'
+    }
+    return 'govuk-table__caption--m'
+  }
+
+  get tableCaption(): string {
+    return this.section === GroupListPageSection.COMPLETE ? 'Completed groups' : 'Not started or in progress groups'
+  }
+
   get groupTableArgs(): TableArgs {
     return {
+      caption: this.tableCaption,
+      captionClasses: this.tableCaptionClass,
       attributes: {
         'data-module': 'moj-sortable-table',
       },

--- a/server/groupOverview/allocations/groupAllocationsPresenter.test.ts
+++ b/server/groupOverview/allocations/groupAllocationsPresenter.test.ts
@@ -277,3 +277,66 @@ describe('resultsText', () => {
     )
   })
 })
+
+describe('tableCaptionClass', () => {
+  it('should return govuk-visually-hidden when there are no rows', () => {
+    const baseGroupOverview = ProgrammeGroupOverviewFactory.build()
+    const groupOverview = {
+      ...baseGroupOverview,
+      pagedGroupData: {
+        ...baseGroupOverview.pagedGroupData,
+        content: [] as typeof baseGroupOverview.pagedGroupData.content,
+      },
+    }
+
+    const presenter = new GroupAllocationsPresenter(
+      GroupAllocationsPageSection.Allocated,
+      groupOverview,
+      '1234',
+      GroupAllocationsFilter.empty(),
+    )
+
+    expect(presenter.tableCaptionClass).toBe('govuk-visually-hidden')
+  })
+
+  it('should return govuk-table__caption--m when rows exist', () => {
+    const groupOverview = ProgrammeGroupOverviewFactory.build()
+
+    const presenter = new GroupAllocationsPresenter(
+      GroupAllocationsPageSection.Allocated,
+      groupOverview,
+      '1234',
+      GroupAllocationsFilter.empty(),
+    )
+
+    expect(presenter.tableCaptionClass).toBe('govuk-table__caption--m')
+  })
+})
+
+describe('tableCaption', () => {
+  it('should return Allocated to <group code> for the allocated section', () => {
+    const groupOverview = ProgrammeGroupOverviewFactory.build()
+
+    const presenter = new GroupAllocationsPresenter(
+      GroupAllocationsPageSection.Allocated,
+      groupOverview,
+      '1234',
+      GroupAllocationsFilter.empty(),
+    )
+
+    expect(presenter.tableCaption).toBe('Allocated to BCCDD1')
+  })
+
+  it('should return Waitlist for Building Choices for the waitlist section', () => {
+    const groupOverview = ProgrammeGroupOverviewFactory.build()
+
+    const presenter = new GroupAllocationsPresenter(
+      GroupAllocationsPageSection.Waitlist,
+      groupOverview,
+      '1234',
+      GroupAllocationsFilter.empty(),
+    )
+
+    expect(presenter.tableCaption).toBe('Waitlist for Building Choices')
+  })
+})

--- a/server/groupOverview/allocations/groupAllocationsPresenter.ts
+++ b/server/groupOverview/allocations/groupAllocationsPresenter.ts
@@ -61,6 +61,19 @@ export default class GroupAllocationsPresenter extends GroupServiceLayoutPresent
     return `Showing <strong>${start}</strong> to <strong>${end}</strong> of <strong>${totalElements}</strong> results`
   }
 
+  get tableCaptionClass(): string {
+    if (this.group.pagedGroupData.content.length === 0) {
+      return 'govuk-visually-hidden'
+    }
+    return 'govuk-table__caption--m'
+  }
+
+  get tableCaption(): string {
+    return this.section === GroupAllocationsPageSection.Waitlist
+      ? 'Waitlist for Building Choices'
+      : `Allocated to ${this.group.group.code}`
+  }
+
   getSubNavArgs(): { items: { text: string; href: string; active: boolean }[] } {
     const nameCrnFilter = this.filter.nameOrCRN === undefined ? `` : `?nameOrCRN=${this.filter.nameOrCRN}`
     return {

--- a/server/groupOverview/allocations/groupAllocationsView.ts
+++ b/server/groupOverview/allocations/groupAllocationsView.ts
@@ -63,6 +63,8 @@ export default class GroupAllocationsView {
 
   getGroupAllocationsTableArgs(): TableArgs {
     return {
+      caption: this.presenter.tableCaption,
+      captionClasses: this.presenter.tableCaptionClass,
       attributes: {
         'data-module': 'moj-sortable-table',
       },

--- a/server/groupOverview/schedule/scheduleView.ts
+++ b/server/groupOverview/schedule/scheduleView.ts
@@ -44,7 +44,7 @@ export default class ScheduleView {
         'data-module': 'moj-sortable-table',
       },
       caption: 'Schedule overview',
-      captionClasses: 'govuk-table__caption--m',
+      captionClasses: 'govuk-visually-hidden',
       head: [
         {
           text: 'Session name',

--- a/server/referralDetails/attendanceHistory/attendanceHistoryView.ts
+++ b/server/referralDetails/attendanceHistory/attendanceHistoryView.ts
@@ -13,6 +13,8 @@ export default class AttendanceHistoryView {
 
   get groupTableArgs(): TableArgs {
     return {
+      caption: 'Attendance record and session notes',
+      captionClasses: 'govuk-visually-hidden',
       attributes: {
         'data-module': 'moj-sortable-table',
       },

--- a/server/sessionSchedule/sessionAttendance/sessionScheduleAttendancePresenter.test.ts
+++ b/server/sessionSchedule/sessionAttendance/sessionScheduleAttendancePresenter.test.ts
@@ -131,6 +131,59 @@ describe('SessionScheduleAttendancePresenter', () => {
       )
     })
 
+    it('renders the new scheduled caption with the left-aligned class', () => {
+      const presenter = new SessionScheduleAttendancePresenter(groupId, mockGroupSessionsData)
+      const accordionItems = presenter.getAccordionItems()
+      const firstModuleContent = accordionItems[0].content.html
+
+      expect(firstModuleContent).toContain(
+        '<caption class="govuk-table__caption--s govuk-!-text-align-left"><strong>Scheduled Module 1: Getting Started session</strong></caption>',
+      )
+    })
+
+    it('does not append "session" in caption for pre-group one-to-ones and post-programme reviews', () => {
+      const modules = ['Pre-group one-to-ones', 'Post-programme reviews'].map((name, index) => ({
+        id: `module-special-${index + 1}`,
+        number: index + 1,
+        name,
+        scheduleButtonText: `Schedule ${name}`,
+        startDateText: {
+          estimatedStartDateText: 'Estimated start date',
+          sessionStartDate: '15 March 2025',
+        },
+        sessions: [
+          {
+            id: `session-special-${index + 1}`,
+            number: 1,
+            name: `${name} 1`,
+            type: 'One-to-one',
+            isCatchup: false,
+            participants: ['John Doe'],
+            dateOfSession: '15 March 2025',
+            timeOfSession: '9:30am to 11:00am',
+            facilitators: ['Facilitator 1'],
+          },
+        ],
+      }))
+
+      const dataWithSpecialModules = {
+        ...mockGroupSessionsData,
+        modules,
+      }
+
+      const presenter = new SessionScheduleAttendancePresenter(groupId, dataWithSpecialModules)
+      const accordionItems = presenter.getAccordionItems()
+
+      expect(accordionItems[0].content.html).toContain(
+        '<caption class="govuk-table__caption--s govuk-!-text-align-left"><strong>Scheduled Pre-group one-to-ones</strong></caption>',
+      )
+      expect(accordionItems[0].content.html).not.toContain('Pre-group one-to-ones session')
+      expect(accordionItems[1].content.html).toContain(
+        '<caption class="govuk-table__caption--s govuk-!-text-align-left"><strong>Scheduled Post-programme reviews</strong></caption>',
+      )
+      expect(accordionItems[1].content.html).not.toContain('Post-programme reviews session')
+    })
+
     it('shows the original session type when catch-up is false', () => {
       const presenter = new SessionScheduleAttendancePresenter(groupId, mockGroupSessionsData)
       const accordionItems = presenter.getAccordionItems()

--- a/server/sessionSchedule/sessionAttendance/sessionScheduleAttendancePresenter.test.ts
+++ b/server/sessionSchedule/sessionAttendance/sessionScheduleAttendancePresenter.test.ts
@@ -137,7 +137,7 @@ describe('SessionScheduleAttendancePresenter', () => {
       const firstModuleContent = accordionItems[0].content.html
 
       expect(firstModuleContent).toContain(
-        '<caption class="govuk-table__caption--s govuk-!-text-align-left"><strong>Scheduled Module 1: Getting Started session</strong></caption>',
+        '<caption class="govuk-table__caption--s govuk-!-text-align-left"><strong>Scheduled Module 1: Getting Started sessions</strong></caption>',
       )
     })
 

--- a/server/sessionSchedule/sessionAttendance/sessionScheduleAttendancePresenter.ts
+++ b/server/sessionSchedule/sessionAttendance/sessionScheduleAttendancePresenter.ts
@@ -76,6 +76,11 @@ export default class SessionScheduleAttendancePresenter extends GroupServiceLayo
     return `${moduleSession.name ?? ''}`.trim()
   }
 
+  private moduleHeadingAppended(moduleSession: ProgrammeGroupModuleSessionsResponseGroupModule): string {
+    const heading = this.moduleHeading(moduleSession)
+    return heading === 'Pre-group one-to-ones' || heading === 'Post-programme reviews' ? '' : ' session'
+  }
+
   private moduleContent(moduleSession: ProgrammeGroupModuleSessionsResponseGroupModule) {
     const sessions = Array.isArray(moduleSession.sessions) ? moduleSession.sessions : []
 
@@ -83,6 +88,7 @@ export default class SessionScheduleAttendancePresenter extends GroupServiceLayo
       sessions.length > 0
         ? `
       <table class="govuk-table" data-module="moj-sortable-table">
+      <caption class="govuk-table__caption--s govuk-!-text-align-left"><strong>Scheduled ${this.moduleHeading(moduleSession)}${this.moduleHeadingAppended(moduleSession)}</strong></caption>
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header">Session name</th>

--- a/server/sessionSchedule/sessionAttendance/sessionScheduleAttendancePresenter.ts
+++ b/server/sessionSchedule/sessionAttendance/sessionScheduleAttendancePresenter.ts
@@ -78,7 +78,7 @@ export default class SessionScheduleAttendancePresenter extends GroupServiceLayo
 
   private moduleHeadingAppended(moduleSession: ProgrammeGroupModuleSessionsResponseGroupModule): string {
     const heading = this.moduleHeading(moduleSession)
-    return heading === 'Pre-group one-to-ones' || heading === 'Post-programme reviews' ? '' : ' session'
+    return heading === 'Pre-group one-to-ones' || heading === 'Post-programme reviews' ? '' : ' sessions'
   }
 
   private moduleContent(moduleSession: ProgrammeGroupModuleSessionsResponseGroupModule) {

--- a/server/views/availabilityAndMotivation/availability.njk
+++ b/server/views/availabilityAndMotivation/availability.njk
@@ -11,6 +11,7 @@
       <h2 class="govuk-heading-l">Availability</h2>
       {{ govukInsetText(importFromDeliusText) }}
       <p>{{ generalAvailabilityText }}</p>
+      <h3 class="{{ availabilityTableHeading.classes }}">{{ availabilityTableHeading.text }}</h3>
       {{ govukTable(availabilityTableArgs) }}
 
       {% if presenter.availability.otherDetails !== '' %}

--- a/server/views/components/multi-select/macro.njk
+++ b/server/views/components/multi-select/macro.njk
@@ -1,5 +1,7 @@
 {% macro multiSelect(tableArgs, idPrefix = 'multi-select-') %}
   {% set headers = tableArgs.headers %}
   {% set rows = tableArgs.rows %}
+  {% set caption = tableArgs.caption %}
+  {% set captionClasses = tableArgs.captionClasses %}
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/server/views/components/multi-select/template.njk
+++ b/server/views/components/multi-select/template.njk
@@ -1,6 +1,9 @@
 <!-- MOJ design system multi-select table converted to a nunjucks template for easy re-use -->
 
   <table class="govuk-table" data-module="moj-multi-select" data-id-prefix="{{ idPrefix }}">
+    {% if caption %}
+    <caption class="govuk-table__caption{% if captionClasses %} {{ captionClasses }}{% endif %}">{{ caption }}</caption>
+    {% endif %}
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header" scope="col" id="{{ idPrefix }}select-all"></th>

--- a/server/views/editSession/editSession.njk
+++ b/server/views/editSession/editSession.njk
@@ -38,14 +38,13 @@
        {% if successMessageArgs !== null %}
           {{ mojAlert(successMessageArgs) }}
         {% endif %}
+      <h2 class="{{ attendanceHeading.classes }}">{{ attendanceHeading.text }}</h2>
       <form method="post" novalidate>
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
         {% if hasMultipleReferrals %}
           {{ multiSelect(attendanceTableArgs) }}
         {% elif hasMultipleReferrals != true %}
-          {% set tableArgs = attendanceTableArgs %}
-          {% set tableArgs = { rows: tableArgs.rows, head: tableArgs.head, caption: "Attendance and session notes", captionClasses: "govuk-heading-m" } %}
-          {{ govukTable(tableArgs) }}
+          {{ govukTable(attendanceTableArgs) }}
           {{ govukInput(singleReferral) }}
         {% endif %}
         {% if hasReferral == false %}
@@ -57,4 +56,3 @@
     </div>
   </div>
 {% endblock %}
-

--- a/server/views/editSession/editSession.njk
+++ b/server/views/editSession/editSession.njk
@@ -32,8 +32,6 @@
         {% if errorSummary !== null %}
           {{ govukErrorSummary(errorSummary) }}
         {% endif %}
-
-        <h2 class="govuk-heading-m">Attendance and session notes</h2>
       </div>
 
     <div class="govuk-grid-column-two-thirds">
@@ -46,7 +44,7 @@
           {{ multiSelect(attendanceTableArgs) }}
         {% elif hasMultipleReferrals != true %}
           {% set tableArgs = attendanceTableArgs %}
-          {% set tableArgs = { rows: tableArgs.rows, head: tableArgs.head, caption: "Attendance and session notes", captionClasses: "govuk-visually-hidden" } %}
+          {% set tableArgs = { rows: tableArgs.rows, head: tableArgs.head, caption: "Attendance and session notes", captionClasses: "govuk-heading-m" } %}
           {{ govukTable(tableArgs) }}
           {{ govukInput(singleReferral) }}
         {% endif %}

--- a/server/views/editSession/editSession.njk
+++ b/server/views/editSession/editSession.njk
@@ -45,7 +45,9 @@
         {% if hasMultipleReferrals %}
           {{ multiSelect(attendanceTableArgs) }}
         {% elif hasMultipleReferrals != true %}
-          {{ govukTable(attendanceTableArgs) }}
+          {% set tableArgs = attendanceTableArgs %}
+          {% set tableArgs = { rows: tableArgs.rows, head: tableArgs.head, caption: "Attendance and session notes", captionClasses: "govuk-visually-hidden" } %}
+          {{ govukTable(tableArgs) }}
           {{ govukInput(singleReferral) }}
         {% endif %}
         {% if hasReferral == false %}


### PR DESCRIPTION
Table captions to be added to tables detailed in the Figma: https://www.figma.com/design/Y1h09XHyEI9O8KZoOpvlTS/Accredited-Programmes--Community-?node-id=15095-80846&t=3e86qgLNwahNXzQc-1

### Details below taken from Figma

**Case list**

1. Additional styling: Use govuk-table__caption--m
2. Additional heading class: No
3. Caption visible: Yes
4. ‘Open referrals’ for Open referrals tab
5. ‘Closed referrals’ for Closed referrals tab

**Groups list**

1. Additional styling: Use govuk-table__caption--m
2. Additional heading class: No
3. Caption visible: Yes
4. ‘Not started or in progress groups’ for Not started or in progress tab
5. ‘Completed groups’ for Completed tab

**Allocations and waitlist**

1. Additional styling: Use govuk-table__caption--m
2. Additional heading class: No
3. Caption visible: Yes
4. ‘Allocated to [group code]’ eg ‘Allocated to BCCDD1’ for Allocations tab
5. ‘Waitlist for Building Choices’ for Waitlist tab

**Schedule overview**

1. Make the existing heading a table caption instead, and apply the changes below
2. Additional styling: No (as it’s now hidden)
3. Additional heading class: No
4. Caption visible: No
5. No change: ‘Schedule overview’ [hidden]

**Sessions and attendance**

1. Additional styling: Use govuk-table__caption--s
2. Additional heading class: No
3. Caption visible: Yes
4. ‘Scheduled pre-group one-to-ones’ for Pre-group one-to-ones section
5. ‘Scheduled Getting started sessions’ for Getting started section
6. ‘Scheduled Managing myself sessions’ for Managing myself section
7. ‘Scheduled Managing life’s problems sessions’ for Managing life’s problems section
8. ‘Scheduled Managing people around me sessions’ for Managing people around me section
9. ‘Scheduled Bringing it all together sessions’ for Bringing it all together section
10. ‘Scheduled post-programme reviews’ for Post-programme reviews section

**Attendance and session notes table (inside a session)**

We assumed that by making the current heading the table caption, any success messages will now need to show above the caption (instead of between the heading and table) - as shown in the visual

1. Additional styling: Use govuk-table__caption--m
2. Additional heading class: Yes - h2
3. Caption visible: Yes
4. ‘Attendance and session notes’
Additional styling: No (as it’s hidden)
Additional heading class: No
Caption visible: No
‘Attendance record and session notes’ [hidden]

**Availability table**

1. Additional styling: Use govuk-table__caption--s
2. Additional heading class: Yes - h3 (as ‘Other availability details’ underneath also has an h3 class)
3. Caption visible: Yes
4. ‘Availability schedule’