### PR TITLE
feat: Add group size reporting endpoint

### DIFF
--- a/server/@types/manageAndDeliverApi/imported/index.d.ts
+++ b/server/@types/manageAndDeliverApi/imported/index.d.ts
@@ -352,6 +352,22 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/dev/seed/referrals': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post: operations['seedReferrals']
+    delete: operations['dangerouslyDeleteAllReferrals']
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/admin/populate-personal-details': {
     parameters: {
       query?: never
@@ -408,6 +424,22 @@ export interface paths {
      * @description Requires role SAR_DATA_ACCESS or additional role as specified by hmpps.sar.additionalAccessRole configuration.
      */
     get: operations['getSarContentByReference']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/subject-access-request/template': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get: operations['getServiceTemplate']
     put?: never
     post?: never
     delete?: never
@@ -629,6 +661,26 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/reporting/group-size.csv': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Download group size reporting data as CSV
+     * @description Returns group size reporting data where the earliest possible start date is after groupStartedSince.
+     */
+    get: operations['getGroupSizeReport']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/referral/{referralId}/status-change-details': {
     parameters: {
       query?: never
@@ -830,6 +882,22 @@ export interface paths {
      * @description Get group by GroupCode and in User region
      */
     get: operations['getGroupInUserRegion']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/dev/seed/health': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get: operations['health']
     put?: never
     post?: never
     delete?: never
@@ -2007,6 +2075,17 @@ export interface components {
        */
       message: string
     }
+    SeededReferralInfo: {
+      referralId: string
+      crn: string
+      personName: string
+      requirementId: string
+    }
+    SeedingResult: {
+      /** Format: int32 */
+      count: number
+      referrals: components['schemas']['SeededReferralInfo'][]
+    }
     CreateAvailability: {
       /**
        * Format: uuid
@@ -2650,7 +2729,7 @@ export interface components {
       hasLdc: boolean
       /**
        * @description The text to display in the UI for the LDC status of this referral
-       * @example May need an LDC-adapted programme(Building Choices Plus)
+       * @example May need an LDC-adapted programme (Building Choices Plus)
        */
       hasLdcDisplayText: string
       /**
@@ -2992,9 +3071,9 @@ export interface components {
       /**
        * @description The overall intensity level derived from the PNI assessment
        * @example HIGH
-       * @enum {string}
+       * @enum {string|null}
        */
-      overallIntensity: 'HIGH' | 'MODERATE' | 'ALTERNATIVE_PATHWAY' | 'MISSING_INFORMATION'
+      overallIntensity?: 'HIGH' | 'MODERATE' | 'ALTERNATIVE_PATHWAY' | 'MISSING_INFORMATION' | null
       /** @description Detailed scores across different assessment domains */
       domainScores: components['schemas']['DomainScores']
       /**
@@ -3021,7 +3100,7 @@ export interface components {
        * @description classification associated with PNI Eg. HIGH_RISK, MEDIUM_RISK, LOW_RISK
        * @example HIGH_RISK
        */
-      classification: string
+      classification?: string | null
       /** @example 2 */
       IndividualRiskScores: components['schemas']['IndividualRiskScores']
     }
@@ -3105,29 +3184,29 @@ export interface components {
       totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      first?: boolean
+      last?: boolean
+      /** Format: int32 */
+      numberOfElements?: number
+      pageable?: components['schemas']['PageableObject']
+      sort?: components['schemas']['SortObject']
       /** Format: int32 */
       size?: number
       content?: components['schemas']['ReferralCaseListItem'][]
       /** Format: int32 */
       number?: number
-      first?: boolean
-      last?: boolean
-      pageable?: components['schemas']['PageableObject']
-      sort?: components['schemas']['SortObject']
-      /** Format: int32 */
-      numberOfElements?: number
       empty?: boolean
     }
     PageableObject: {
-      /** Format: int64 */
-      offset?: number
+      paged?: boolean
       /** Format: int32 */
       pageNumber?: number
-      sort?: components['schemas']['SortObject']
       /** Format: int32 */
       pageSize?: number
-      paged?: boolean
+      sort?: components['schemas']['SortObject']
       unpaged?: boolean
+      /** Format: int64 */
+      offset?: number
     }
     ReferralCaseListItem: {
       /** Format: uuid */
@@ -3149,9 +3228,9 @@ export interface components {
       sentenceEndDateSource?: 'REQUIREMENT' | 'LICENCE_CONDITION' | null
     }
     SortObject: {
-      empty?: boolean
       sorted?: boolean
       unsorted?: boolean
+      empty?: boolean
     }
     StatusFilterValues: {
       /**
@@ -3769,17 +3848,17 @@ export interface components {
       totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      first?: boolean
+      last?: boolean
+      /** Format: int32 */
+      numberOfElements?: number
+      pageable?: components['schemas']['PageableObject']
+      sort?: components['schemas']['SortObject']
       /** Format: int32 */
       size?: number
       content?: components['schemas']['Group'][]
       /** Format: int32 */
       number?: number
-      first?: boolean
-      last?: boolean
-      pageable?: components['schemas']['PageableObject']
-      sort?: components['schemas']['SortObject']
-      /** Format: int32 */
-      numberOfElements?: number
       empty?: boolean
     }
     GroupItem: {
@@ -3864,17 +3943,17 @@ export interface components {
       totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      first?: boolean
+      last?: boolean
+      /** Format: int32 */
+      numberOfElements?: number
+      pageable?: components['schemas']['PageableObject']
+      sort?: components['schemas']['SortObject']
       /** Format: int32 */
       size?: number
       content?: components['schemas']['GroupItem'][]
       /** Format: int32 */
       number?: number
-      first?: boolean
-      last?: boolean
-      pageable?: components['schemas']['PageableObject']
-      sort?: components['schemas']['SortObject']
-      /** Format: int32 */
-      numberOfElements?: number
       empty?: boolean
     }
     /** @description Details of a Programme Group including filters and paginated group data. */
@@ -4398,6 +4477,10 @@ export interface components {
       facilitators: components['schemas']['CreateGroupTeamMember'][]
       /** @description The list of coverFacilitators for this group. */
       coverFacilitators?: components['schemas']['CreateGroupTeamMember'][] | null
+    }
+    TeardownResult: {
+      /** Format: int32 */
+      deletedCount: number
     }
   }
   responses: never
@@ -5576,6 +5659,66 @@ export interface operations {
       }
     }
   }
+  seedReferrals: {
+    parameters: {
+      query?: {
+        count?: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['SeedingResult']
+        }
+      }
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  dangerouslyDeleteAllReferrals: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['TeardownResult']
+        }
+      }
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
   populatePersonalDetails: {
     parameters: {
       query?: never
@@ -5697,6 +5840,62 @@ export interface operations {
         }
         content: {
           'application/json': Record<string, never>
+        }
+      }
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description The client does not have authorisation to make this request */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Unexpected error occurred */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  getServiceTemplate: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Request successfully processed - return template file content */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'plain/text': string
         }
       }
       /** @description Bad Request */
@@ -6445,6 +6644,50 @@ export interface operations {
       }
     }
   }
+  getGroupSizeReport: {
+    parameters: {
+      query: {
+        /**
+         * @description Only include groups that started after this date-time (must be in the past).
+         * @example 2026-05-18T13:30:00
+         */
+        groupStartedSince: string
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description CSV file containing group size reporting data. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'text/csv': string
+        }
+      }
+      /** @description Invalid or non-past groupStartedSince query parameter. */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'text/csv': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'text/csv': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
   getStatusChangeDetails: {
     parameters: {
       query?: never
@@ -6942,7 +7185,7 @@ export interface operations {
           'application/json': components['schemas']['ErrorResponse']
         }
       }
-      /** @description The PNI Score does not exist for this CRN */
+      /** @description The person resource itself is not found */
       404: {
         headers: {
           [name: string]: unknown
@@ -7036,6 +7279,37 @@ export interface operations {
       }
       /** @description Forbidden. The client is not authorised to retrieve group details. */
       403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  health: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': {
+            [key: string]: string
+          }
+        }
+      }
+      /** @description Bad Request */
+      400: {
         headers: {
           [name: string]: unknown
         }

--- a/server/reporting/reportingController.test.ts
+++ b/server/reporting/reportingController.test.ts
@@ -1,0 +1,91 @@
+import { Express } from 'express'
+import request from 'supertest'
+
+import createUserToken from '../testutils/createUserToken'
+import AccreditedProgrammesManageAndDeliverService from '../services/accreditedProgrammesManageAndDeliverService'
+import { appWithAllRoutes, user as defaultUser } from '../routes/testutils/appSetup'
+
+const hmppsAuthClientBuilder = jest.fn()
+
+jest.mock('../services/accreditedProgrammesManageAndDeliverService')
+jest.mock('../data/hmppsAuthClient')
+
+const accreditedProgrammesManageAndDeliverService = new AccreditedProgrammesManageAndDeliverService(
+  hmppsAuthClientBuilder,
+) as jest.Mocked<AccreditedProgrammesManageAndDeliverService>
+
+let app: Express
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('Reporting controller', () => {
+  it('returns CSV for group size report when user has reporting role', async () => {
+    const csv = 'groupCode,size\\nGRP-001,12\\n'
+    accreditedProgrammesManageAndDeliverService.getGroupSizeReport.mockResolvedValue(csv)
+
+    app = appWithAllRoutes({
+      services: {
+        accreditedProgrammesManageAndDeliverService,
+      },
+      userSupplier: () => ({
+        ...defaultUser,
+        token: createUserToken(['ROLE_ACCREDITED_PROGRAMMES_MANAGE_AND_DELIVER_API__ACPMAD_UI_REPORTING']),
+      }),
+    })
+
+    await request(app)
+      .get('/reporting/group-size.csv?groupStartedSince=2026-05-18T13:30:00')
+      .expect(200)
+      .expect('Content-Type', /text\/csv/)
+      .expect(res => {
+        expect(res.text).toBe(csv)
+      })
+
+    expect(accreditedProgrammesManageAndDeliverService.getGroupSizeReport).toHaveBeenCalledWith(
+      'user1',
+      '2026-05-18T13:30:00',
+    )
+  })
+
+  it('redirects to auth error when user does not have reporting role', async () => {
+    app = appWithAllRoutes({
+      services: {
+        accreditedProgrammesManageAndDeliverService,
+      },
+      userSupplier: () => ({
+        ...defaultUser,
+        token: createUserToken(['ROLE_PROBATION']),
+      }),
+    })
+
+    await request(app)
+      .get('/reporting/group-size.csv?groupStartedSince=2026-05-18T13:30:00')
+      .expect(302)
+      .expect('Location', '/authError')
+
+    expect(accreditedProgrammesManageAndDeliverService.getGroupSizeReport).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when groupStartedSince is not a valid date-time', async () => {
+    app = appWithAllRoutes({
+      services: {
+        accreditedProgrammesManageAndDeliverService,
+      },
+      userSupplier: () => ({
+        ...defaultUser,
+        token: createUserToken(['ROLE_ACCREDITED_PROGRAMMES_MANAGE_AND_DELIVER_API__ACPMAD_UI_REPORTING']),
+      }),
+    })
+
+    await request(app)
+      .get('/reporting/group-size.csv?groupStartedSince=not-a-date')
+      .expect(400)
+      .expect(res => {
+        expect(res.text).toBe('groupStartedSince must be a valid date-time string')
+      })
+
+    expect(accreditedProgrammesManageAndDeliverService.getGroupSizeReport).not.toHaveBeenCalled()
+  })
+})

--- a/server/reporting/reportingController.test.ts
+++ b/server/reporting/reportingController.test.ts
@@ -23,7 +23,12 @@ afterEach(() => {
 describe('Reporting controller', () => {
   it('returns CSV for group size report when user has reporting role', async () => {
     const csv = 'groupCode,size\\nGRP-001,12\\n'
-    accreditedProgrammesManageAndDeliverService.getGroupSizeReport.mockResolvedValue(csv)
+    accreditedProgrammesManageAndDeliverService.getGroupSizeReport.mockResolvedValue({
+      csv,
+      headers: {
+        'Content-Disposition': 'attachment; filename="group-size-report.csv"',
+      },
+    })
 
     app = appWithAllRoutes({
       services: {
@@ -39,6 +44,7 @@ describe('Reporting controller', () => {
       .get('/reporting/group-size.csv?groupStartedSince=2026-05-18T13:30:00')
       .expect(200)
       .expect('Content-Type', /text\/csv/)
+      .expect('Content-Disposition', 'attachment; filename="group-size-report.csv"')
       .expect(res => {
         expect(res.text).toBe(csv)
       })

--- a/server/reporting/reportingController.ts
+++ b/server/reporting/reportingController.ts
@@ -31,9 +31,15 @@ export default class ReportingController {
     }
 
     const { username } = req.user
-    const csv = await this.accreditedProgrammesManageAndDeliverService.getGroupSizeReport(username, groupStartedSince)
+    const { csv, headers } = await this.accreditedProgrammesManageAndDeliverService.getGroupSizeReport(
+      username,
+      groupStartedSince,
+    )
 
     res.setHeader('Content-Type', 'text/csv; charset=utf-8')
+    Object.entries(headers).forEach(([key, value]) => {
+      res.setHeader(key, value)
+    })
     res.send(csv)
   }
 }

--- a/server/reporting/reportingController.ts
+++ b/server/reporting/reportingController.ts
@@ -1,0 +1,39 @@
+import { Request, Response } from 'express'
+
+import AccreditedProgrammesManageAndDeliverService from '../services/accreditedProgrammesManageAndDeliverService'
+
+export default class ReportingController {
+  constructor(
+    private readonly accreditedProgrammesManageAndDeliverService: AccreditedProgrammesManageAndDeliverService,
+  ) {}
+
+  private static hasValidDateString(value: unknown): value is string {
+    if (typeof value !== 'string') {
+      return false
+    }
+
+    const parsedDate = new Date(value)
+    if (Number.isNaN(parsedDate.getTime())) {
+      return false
+    }
+
+    // Ensure the parsed value can be serialised as an ISO date string.
+    parsedDate.toISOString()
+    return true
+  }
+
+  async downloadGroupSizeReport(req: Request, res: Response): Promise<void> {
+    const { groupStartedSince } = req.query
+
+    if (!ReportingController.hasValidDateString(groupStartedSince)) {
+      res.status(400).send('groupStartedSince must be a valid date-time string')
+      return
+    }
+
+    const { username } = req.user
+    const csv = await this.accreditedProgrammesManageAndDeliverService.getGroupSizeReport(username, groupStartedSince)
+
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8')
+    res.send(csv)
+  }
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -78,6 +78,17 @@ export default function routes({ accreditedProgrammesManageAndDeliverService }: 
 
   router.get(
     '/reporting/group-size.csv',
+    /**
+     * @INFO - At time of writing the user REFER_MONITOR_PP
+     * does not have the reporting role.  i (wilson) will open a
+     * PR on the hmpps-auth repo to create and assign that role.  until
+     * then, if you want to test this endpoint, you will need to comment out
+     * the call to `authorisationMiddleware` and re-start the server.
+     * the ROLE_PROBATION is granted through the (wiremocked) nDelius
+     * integration, but the reporting role needs to be assigned separately
+     * through hmpps-auth.
+     * --TJWC 2026-05-19
+     * */
     authorisationMiddleware([reportingRole]),
     asyncMiddleware(async (req, res) => {
       await reportingController.downloadGroupSizeReport(req, res)

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -12,9 +12,11 @@ import GroupOverviewController from '../groupOverview/groupOverviewController'
 import RemoveFromGroupController from '../groupOverview/removeFromGroup/removeFromGroupController'
 import LdcController from '../ldc/ldcController'
 import LocationPreferencesController from '../availabilityAndMotivation/locationPreferences/locationPreferencesController'
+import authorisationMiddleware from '../middleware/authorisationMiddleware'
 import asyncMiddleware from '../middleware/asyncMiddleware'
 import PniController from '../pni/pniController'
 import ReferralDetailsController from '../referralDetails/referralDetailsController'
+import ReportingController from '../reporting/reportingController'
 import RisksAndNeedsController from '../risksAndNeeds/risksAndNeedsController'
 import type { Services } from '../services'
 import SessionScheduleController from '../sessionSchedule/sessionScheduleController'
@@ -58,6 +60,9 @@ export default function routes({ accreditedProgrammesManageAndDeliverService }: 
   const homeController = new HomeController()
   const addAvailabilityController = new AddAvailabilityController(accreditedProgrammesManageAndDeliverService)
   const editGroupController = new EditGroupController(accreditedProgrammesManageAndDeliverService)
+  const reportingController = new ReportingController(accreditedProgrammesManageAndDeliverService)
+
+  const reportingRole = 'ROLE_ACCREDITED_PROGRAMMES_MANAGE_AND_DELIVER_API__ACPMAD_UI_REPORTING'
 
   get('/', async (req, res, next) => {
     await homeController.showHomePage(req, res)
@@ -70,6 +75,14 @@ export default function routes({ accreditedProgrammesManageAndDeliverService }: 
   get('/region/closed-referrals', async (req, res, next) => {
     await caselistController.showClosedCaselist(req, res)
   })
+
+  router.get(
+    '/reporting/group-size.csv',
+    authorisationMiddleware([reportingRole]),
+    asyncMiddleware(async (req, res) => {
+      await reportingController.downloadGroupSizeReport(req, res)
+    }),
+  )
 
   get('/referral-details/:id/personal-details', async (req, res, next) => {
     await referralDetailsController.showPersonalDetailsPage(req, res)

--- a/server/services/accreditedProgrammesManageAndDeliverService.ts
+++ b/server/services/accreditedProgrammesManageAndDeliverService.ts
@@ -69,6 +69,8 @@ import {
   UpdateGroupResponse,
   UserTeamMember,
 } from '@manage-and-deliver-api'
+import type { Response as SuperAgentResponse } from 'superagent'
+
 import { CaselistFilterParams } from '../caselist/CaseListFilterParams'
 import config, { ApiConfig } from '../config'
 import type { HmppsAuthClient, RestClientBuilderWithoutToken } from '../data'
@@ -149,14 +151,26 @@ export default class AccreditedProgrammesManageAndDeliverService implements IAcc
     })) as CaseListReferrals
   }
 
-  async getGroupSizeReport(username: ExpressUsername, groupStartedSince: string): Promise<string> {
+  async getGroupSizeReport(
+    username: ExpressUsername,
+    groupStartedSince: string,
+  ): Promise<{
+    csv: string
+    headers: { [key: string]: string }
+  }> {
     const restClient = await this.createRestClientFromUsername(username)
-    return (await restClient.get({
+    const response = await restClient.get<SuperAgentResponse>({
       path: '/reporting/group-size.csv',
       headers: { Accept: 'text/csv' },
       query: { groupStartedSince },
       responseType: 'text',
-    })) as string
+      raw: true,
+    })
+
+    return {
+      csv: response.body,
+      headers: response.headers,
+    }
   }
 
   async getGroupAllocatedMembers(

--- a/server/services/accreditedProgrammesManageAndDeliverService.ts
+++ b/server/services/accreditedProgrammesManageAndDeliverService.ts
@@ -149,6 +149,16 @@ export default class AccreditedProgrammesManageAndDeliverService implements IAcc
     })) as CaseListReferrals
   }
 
+  async getGroupSizeReport(username: ExpressUsername, groupStartedSince: string): Promise<string> {
+    const restClient = await this.createRestClientFromUsername(username)
+    return (await restClient.get({
+      path: '/reporting/group-size.csv',
+      headers: { Accept: 'text/csv' },
+      query: { groupStartedSince },
+      responseType: 'text',
+    })) as string
+  }
+
   async getGroupAllocatedMembers(
     username: ExpressUsername,
     groupId: string,


### PR DESCRIPTION
**WHAT**

This PR introduces a new façade wrapper around the `GET /reporting/group-size.csv` endpoint on the API.  

**WHY**

As part the the reporting architecture (outlined in a [doc here](https://github.com/ministryofjustice/hmpps-accredited-programmes-manage-and-deliver-api/blob/main/docs/2026-05-reporting.md)) we are exposing Group Size reporting through an endpoint which allows the user to download a .csv file. 

This is point-in-time, not event-driven, reporting, and therefore event oriented system (e.g. App Insights) would not be appropriate.

**HOW**

* Generated the API types from the new endpoint (`index.d.ts`)
* Created the `ReportingController` which is a simple façade around the API endpoints

