### PR TITLE
remove the radio button option deprioritised

### DIFF
--- a/server/groupOverview/removeFromGroup/removeFromGroupUpdateStatusPresenter.test.ts
+++ b/server/groupOverview/removeFromGroup/removeFromGroupUpdateStatusPresenter.test.ts
@@ -36,4 +36,50 @@ describe('RemoveFromGroupUpdateStatusPresenter', () => {
       updatedStatus: { errorMessage: null, value: '' },
     })
   })
+
+  it('should generate status radios from available statuses', () => {
+    const presenter = new RemoveFromGroupUpdateStatusPresenter(groupId, statusDetails, backLinkUri, groupManagementData)
+
+    expect(presenter.generateStatusUpdateRadios()).toEqual([
+      {
+        checked: false,
+        hint: {
+          text: 'The person has been assessed as suitable and can be allocated to a group.',
+        },
+        text: 'Awaiting allocation',
+        value: 'bb1e8c72-cf52-4297-94a4-3745c2a25178',
+      },
+      {
+        checked: false,
+        hint: {
+          text: 'The person meets the suitability criteria but is not ready to start the programme. The referral will be paused until they are ready.',
+        },
+        text: 'Suitable but not ready',
+        value: '336b59cd-b467-4305-8547-6a645a8a3f91',
+      },
+      {
+        checked: false,
+        hint: {
+          text: 'The person has been recalled. Depending on the recall type, the referral may be withdrawn or returned to awaiting assessment.',
+        },
+        text: 'Recall',
+        value: 'aec91cd3-fba0-40a4-a5c6-7578b596af75',
+      },
+      {
+        checked: false,
+        hint: {
+          text: 'The person is not suitable for the programme or cannot continue with it. The referral will be returned to court.',
+        },
+        text: 'Return to court',
+        value: 'e9fb9e3a-147b-4f26-aa0c-d852db4b7fef',
+      },
+    ])
+  })
+
+  it('should hide the Deprioritised option', () => {
+    const presenter = new RemoveFromGroupUpdateStatusPresenter(groupId, statusDetails, backLinkUri, groupManagementData)
+    const radios = presenter.generateStatusUpdateRadios()
+
+    expect(radios.find(radio => radio.text === 'Deprioritised')).toBeUndefined()
+  })
 })

--- a/server/groupOverview/removeFromGroup/removeFromGroupUpdateStatusPresenter.ts
+++ b/server/groupOverview/removeFromGroup/removeFromGroupUpdateStatusPresenter.ts
@@ -41,14 +41,16 @@ export default class RemoveFromGroupUpdateStatusPresenter {
   generateStatusUpdateRadios() {
     const statusRadios: RadiosArgsItem[] = []
     this.statusDetails.availableStatuses.forEach((status: ReferralStatus) => {
-      statusRadios.push({
-        value: status.id,
-        text: status.status,
-        hint: {
-          text: status.transitionDescription,
-        },
-        checked: this.fields.updatedStatus.value.toLowerCase() === status.id.toLowerCase(),
-      })
+      if (status.status !== 'Deprioritised') {
+        statusRadios.push({
+          value: status.id,
+          text: status.status,
+          hint: {
+            text: status.transitionDescription,
+          },
+          checked: this.fields.updatedStatus.value.toLowerCase() === status.id.toLowerCase(),
+        })
+      }
     })
     return statusRadios
   }


### PR DESCRIPTION
remove the radio button option 'deprioritised' from the status to remove someone from a group.

example: https://accredited-programmes-manage-and-deliver-dev.hmpps.service.justice.gov.uk/remove-from-group/a34a6291-5415-487c-ae70-c8ec698f9733/d92b0493-b7f2-4ba9-a7b0-d841ef18dcb7/update-status