### PR TITLE
some page title and heading fixes

### DIFF
--- a/server/availabilityAndMotivation/availabilityAndMotivationPresenter.test.ts
+++ b/server/availabilityAndMotivation/availabilityAndMotivationPresenter.test.ts
@@ -22,7 +22,7 @@ describe('AvailabilityAndMotivationPresenter', () => {
         AvailabilityAndMotivationPageSelection.MotivationBackgroundAndNonAssociationsTab,
       )
 
-      expect(presenter.pageTitle).toBe('Motivation, background and non-associations - Availability and motivation')
+      expect(presenter.pageTitle).toBe('Add motivation, background and non-associations - Availability and motivation')
     })
 
     it('returns the default title for Availability tab', () => {

--- a/server/availabilityAndMotivation/availabilityAndMotivationPresenter.ts
+++ b/server/availabilityAndMotivation/availabilityAndMotivationPresenter.ts
@@ -31,7 +31,7 @@ export default class AvailabilityAndMotivationPresenter extends ReferralLayoutPr
       case AvailabilityAndMotivationPageSelection.LocationTab:
         return 'Location - Availability and motivation'
       case AvailabilityAndMotivationPageSelection.MotivationBackgroundAndNonAssociationsTab:
-        return 'Motivation, background and non-associations - Availability and motivation'
+        return 'Add motivation, background and non-associations - Availability and motivation'
       default:
         return 'Availability - Availability and motivation'
     }

--- a/server/createGroup/editGroupController.test.ts
+++ b/server/createGroup/editGroupController.test.ts
@@ -255,7 +255,7 @@ describe('Edit Group Controller', () => {
         })
         .expect(302)
         .expect(res => {
-          expect(res.text).toContain(`Redirecting to /${groupId}/edit-session-date-and-time/reschedule`)
+          expect(res.text).toContain(`Redirecting to /${groupId}/edit-group-days-and-times/reschedule`)
         })
     })
 
@@ -281,7 +281,7 @@ describe('Edit Group Controller', () => {
     })
   })
 
-  describe('GET /:groupId/edit-session-date-and-time/reschedule', () => {
+  describe('GET /:groupId/edit-group-days-and-times/reschedule', () => {
     it('loads the reschedule confirmation page for days and times', async () => {
       const sessionData: Partial<SessionData> = {
         createGroupFormData: {
@@ -307,7 +307,7 @@ describe('Edit Group Controller', () => {
       app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
 
       return request(app)
-        .get(`/${groupId}/edit-session-date-and-time/reschedule`)
+        .get(`/${groupId}/edit-group-days-and-times/reschedule`)
         .expect(200)
         .expect(res => {
           expect(res.text).toContain('Rescheduling other sessions')
@@ -317,7 +317,7 @@ describe('Edit Group Controller', () => {
     })
   })
 
-  describe('POST /:groupId/edit-session-date-and-time/reschedule', () => {
+  describe('POST /:groupId/edit-group-days-and-times/reschedule', () => {
     const sessionData: Partial<SessionData> = {
       createGroupFormData: {
         groupCode: 'TEST123',
@@ -347,7 +347,7 @@ describe('Edit Group Controller', () => {
       })
 
       return request(app)
-        .post(`/${groupId}/edit-session-date-and-time/reschedule`)
+        .post(`/${groupId}/edit-group-days-and-times/reschedule`)
         .type('form')
         .send({ 'reschedule-other-sessions': 'true' })
         .expect(302)
@@ -369,7 +369,7 @@ describe('Edit Group Controller', () => {
       })
 
       return request(app)
-        .post(`/${groupId}/edit-session-date-and-time/reschedule`)
+        .post(`/${groupId}/edit-group-days-and-times/reschedule`)
         .type('form')
         .send({ 'reschedule-other-sessions': 'false' })
         .expect(302)
@@ -386,7 +386,7 @@ describe('Edit Group Controller', () => {
     it('returns with errors if reschedule option is not selected', async () => {
       app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
 
-      return request(app).post(`/${groupId}/edit-session-date-and-time/reschedule`).type('form').send({}).expect(400)
+      return request(app).post(`/${groupId}/edit-group-days-and-times/reschedule`).type('form').send({}).expect(400)
     })
   })
 

--- a/server/createGroup/editGroupController.ts
+++ b/server/createGroup/editGroupController.ts
@@ -139,7 +139,7 @@ export default class EditGroupController extends BaseController {
           ...req.session.createGroupFormData,
           previousSessions: groupDetails.programmeGroupSessionSlots,
         }
-        return res.redirect(`/${groupId}/edit-session-date-and-time/reschedule`)
+        return res.redirect(`/${groupId}/edit-group-days-and-times/reschedule`)
       }
     }
 

--- a/server/editSession/editSessionController.test.ts
+++ b/server/editSession/editSessionController.test.ts
@@ -154,7 +154,7 @@ describe('editSessionDateAndTime', () => {
         })
         .expect(302)
         .expect(res => {
-          expect(res.text).toContain(`Redirecting to /111/6789/edit-session-date-and-time/reschedule`)
+          expect(res.text).toContain(`Redirecting to /111/6789/edit-group-days-and-times/reschedule`)
         })
     })
   })
@@ -176,7 +176,7 @@ describe('submitEditSessionDateAndTime', () => {
       },
     },
   }
-  describe('GET /:groupId/:sessionId/edit-session-date-and-time/reschedule', () => {
+  describe('GET /:groupId/:sessionId/edit-group-days-and-times/reschedule', () => {
     it('should fetch session details with correct parameters and load page correctly', async () => {
       const sessionDetails = rescheduleSessionDetailsFactory.build()
       accreditedProgrammesManageAndDeliverService.getRescheduleSessionDetails.mockResolvedValue(sessionDetails)
@@ -184,7 +184,7 @@ describe('submitEditSessionDateAndTime', () => {
       app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
 
       await request(app)
-        .get(`/111/6789/edit-session-date-and-time/reschedule`)
+        .get(`/111/6789/edit-group-days-and-times/reschedule`)
         .expect(200)
         .expect(res => {
           expect(res.text).toContain('Rescheduling later sessions')
@@ -196,7 +196,7 @@ describe('submitEditSessionDateAndTime', () => {
     })
   })
 
-  describe('POST /:groupId/:sessionId/edit-session-date-and-time/reschedule', () => {
+  describe('POST /:groupId/:sessionId/edit-group-days-and-times/reschedule', () => {
     it('should submit the edit session details correctly', async () => {
       const sessionDetails = rescheduleSessionDetailsFactory.build()
       accreditedProgrammesManageAndDeliverService.getRescheduleSessionDetails.mockResolvedValue(sessionDetails)
@@ -208,7 +208,7 @@ describe('submitEditSessionDateAndTime', () => {
       })
 
       return request(app)
-        .post(`/111/6789/edit-session-date-and-time/reschedule`)
+        .post(`/111/6789/edit-group-days-and-times/reschedule`)
         .type('form')
         .send({
           'reschedule-other-sessions': 'false',

--- a/server/editSession/editSessionController.ts
+++ b/server/editSession/editSessionController.ts
@@ -171,7 +171,7 @@ export default class EditSessionController extends BaseController {
 
         // GROUP sessions and ONE_TO_ONE catch-ups go to the reschedule page
         if (sessionAttendees.sessionType === 'GROUP' && !sessionAttendees.isCatchup) {
-          return res.redirect(`/${groupId}/${sessionId}/edit-session-date-and-time/reschedule`)
+          return res.redirect(`/${groupId}/${sessionId}/edit-group-days-and-times/reschedule`)
         }
 
         // For ONE_TO_ONE sessions, submit directly to API

--- a/server/referralDetails/attendanceHistory/attendanceHistoryPresenter.test.ts
+++ b/server/referralDetails/attendanceHistory/attendanceHistoryPresenter.test.ts
@@ -170,7 +170,7 @@ describe('AttendanceHistoryPresenter', () => {
         referralDetails,
       )
 
-      expect(presenter.pageTitle).toBe("Person's attendance history - Accredited Programmes")
+      expect(presenter.pageTitle).toBe("Person's attendance history")
     })
   })
 })

--- a/server/referralDetails/attendanceHistory/attendanceHistoryPresenter.ts
+++ b/server/referralDetails/attendanceHistory/attendanceHistoryPresenter.ts
@@ -31,7 +31,7 @@ export default class AttendanceHistoryPresenter extends ReferralLayoutPresenter 
   }
 
   get pageTitle(): string {
-    return "Person's attendance history - Accredited Programmes"
+    return "Person's attendance history"
   }
 
   get tableDescription(): string {

--- a/server/referralDetails/statusHistoryPresenter.test.ts
+++ b/server/referralDetails/statusHistoryPresenter.test.ts
@@ -73,7 +73,7 @@ describe('StatusHistoryPresenter', () => {
 
       const presenter = new StatusHistoryPresenter('referral-id', statusHistory, referralDetails)
 
-      expect(presenter.pageTitle).toBe('Status history - Accredited Programmes')
+      expect(presenter.pageTitle).toBe('Status history')
     })
   })
 })

--- a/server/referralDetails/statusHistoryPresenter.ts
+++ b/server/referralDetails/statusHistoryPresenter.ts
@@ -21,7 +21,7 @@ export default class StatusHistoryPresenter extends ReferralLayoutPresenter {
   }
 
   get pageTitle(): string {
-    return 'Status history - Accredited Programmes'
+    return 'Status history'
   }
 
   get errorMessageSummary(): MojAlertComponentArgs | null {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -289,7 +289,7 @@ export default function routes({ accreditedProgrammesManageAndDeliverService }: 
     await editGroupController.editGroupDaysAndTimes(req, res)
   })
 
-  getOrPost('/:groupId/edit-session-date-and-time/reschedule', async (req, res) => {
+  getOrPost('/:groupId/edit-group-days-and-times/reschedule', async (req, res) => {
     await editGroupController.editGroupRescheduleDayTimes(req, res)
   })
 
@@ -419,7 +419,7 @@ export default function routes({ accreditedProgrammesManageAndDeliverService }: 
     await editSessionController.editSessionDateAndTime(req, res)
   })
 
-  getOrPost('/:groupId/:sessionId/edit-session-date-and-time/reschedule', async (req, res, next) => {
+  getOrPost('/:groupId/:sessionId/edit-group-days-and-times/reschedule', async (req, res, next) => {
     await editSessionController.submitEditSessionDateAndTime(req, res)
   })
   getOrPost('/:groupId/:sessionId/delete-session', async (req, res, next) => {

--- a/server/views/sessionSchedule/sessionScheduleWhich.njk
+++ b/server/views/sessionSchedule/sessionScheduleWhich.njk
@@ -1,5 +1,4 @@
 {% extends "../partials/layout.njk" %}
-{% extends "../partials/layout.njk" %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}


### PR DESCRIPTION
URL amended for this page from 
edit-session-date-and-time/reschedule  
to
/edit-group-days-and-times/reschedule :

After:

<img width="1622" height="994" alt="Screenshot 2026-05-29 at 08 57 00" src="https://github.com/user-attachments/assets/51fc8fee-4faa-46c8-9a07-d9fa25b2928f" />

Before

<img width="1622" height="994" alt="Screenshot 2026-05-29 at 08 58 49" src="https://github.com/user-attachments/assets/89cef3d2-dbcb-4e9f-9cb5-32fd1f4d1289" />




**Page title updated to include the word 'Add' at the start:**

<img width="1622" height="994" alt="Screenshot 2026-05-29 at 08 59 55" src="https://github.com/user-attachments/assets/16d05ae3-d83c-4f5a-af7f-8fd142d1d22e" />


