### PR TITLE
fix: increase API socket timeout from 8-10s to 30s 

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -106,10 +106,10 @@ export default {
       url: get('ACCREDITED_PROGRAMMES_MANAGE_AND_DELIVER_URL', 'http://localhost:8080', requiredInProduction),
       healthPath: '/health',
       timeout: {
-        response: 10000,
-        deadline: 10000,
+        response: 30000,
+        deadline: 30000,
       },
-      agent: new AgentConfig(),
+      agent: new AgentConfig(30000),
     },
   },
   sqs: {


### PR DESCRIPTION
to prevent Socket timeout errors

The UI was timing out on slow API responses (e.g. /bff/group/{id}/ALLOCATED) because the socket inactivity timeout was 8s and response/deadline was 10s. The API calls nDelius for user region data on every request to this endpoint, which can take >8s under load. Increasing to 30s prevents premature disconnection. This is a quick mitigation — a better fix would be to cache getUserRegions() in the API so it doesn't call nDelius on every request.