### PR TITLE
Apg 2138/prevent lengthening of past session duration 0306

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ wiremock_mappings/seeded/*.json
 
 # Local helper scripts
 script/add-group-members.sh
+script/add-users-to-sessions.sh

--- a/assets/scss/overrides/_local.scss
+++ b/assets/scss/overrides/_local.scss
@@ -152,15 +152,11 @@
 }
 
 .home-background {
-  background: #f0f4f5;
+  background: #f3f3f3;
   padding: 30px 0;
 }
 
 .heading-background {
   background: white;
   padding-top: 40px;
-}
-
-.primary-navigation-background {
-  background: #f0f4f5;
 }

--- a/server/@types/manageAndDeliverApi/imported/index.d.ts
+++ b/server/@types/manageAndDeliverApi/imported/index.d.ts
@@ -3263,9 +3263,9 @@ export interface components {
       first?: boolean
       last?: boolean
       sort?: components['schemas']['SortObject']
+      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
-      pageable?: components['schemas']['PageableObject']
       empty?: boolean
     }
     PageableObject: {
@@ -3274,9 +3274,9 @@ export interface components {
       sort?: components['schemas']['SortObject']
       /** Format: int32 */
       pageSize?: number
-      paged?: boolean
       /** Format: int32 */
       pageNumber?: number
+      paged?: boolean
       unpaged?: boolean
     }
     ReferralCaseListItem: {
@@ -3936,9 +3936,9 @@ export interface components {
       first?: boolean
       last?: boolean
       sort?: components['schemas']['SortObject']
+      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
-      pageable?: components['schemas']['PageableObject']
       empty?: boolean
     }
     GroupItem: {
@@ -4031,9 +4031,9 @@ export interface components {
       first?: boolean
       last?: boolean
       sort?: components['schemas']['SortObject']
+      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
-      pageable?: components['schemas']['PageableObject']
       empty?: boolean
     }
     /** @description Details of a Programme Group including filters and paginated group data. */
@@ -4654,7 +4654,7 @@ export interface operations {
           'application/json': components['schemas']['EditSessionDateAndTimeResponse']
         }
       }
-      /** @description Bad request - For past sessions (end time has passed), the duration cannot be longer than currently scheduled */
+      /** @description The session duration cannot be longer than originally scheduled. Change the start or end time. */
       400: {
         headers: {
           [name: string]: unknown

--- a/server/@types/manageAndDeliverApi/imported/index.d.ts
+++ b/server/@types/manageAndDeliverApi/imported/index.d.ts
@@ -281,7 +281,7 @@ export interface paths {
     }
     get?: never
     put?: never
-    /** Fetches the personal details and OASys details for specified Referrals */
+    /** Fetches the personal details and OASys details for specified Referrals. Returns 202 immediately and processes in background. */
     post: operations['fetchPersonalDetailsForReferrals']
     delete?: never
     options?: never
@@ -2022,10 +2022,10 @@ export interface components {
        */
       referralIds: string[]
     }
-    FetchPersonalDetailsResponse: {
-      successIds: string[]
-      notFoundIds: string[]
-      failureIds: string[]
+    FetchPersonalDetailsAcceptedResponse: {
+      message: string
+      /** Format: int32 */
+      referralCount: number
     }
     /** @description Response returned when a programme group is created */
     CreateGroupResponse: {
@@ -3263,9 +3263,9 @@ export interface components {
       first?: boolean
       last?: boolean
       sort?: components['schemas']['SortObject']
-      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
+      pageable?: components['schemas']['PageableObject']
       empty?: boolean
     }
     PageableObject: {
@@ -3273,10 +3273,10 @@ export interface components {
       offset?: number
       sort?: components['schemas']['SortObject']
       /** Format: int32 */
-      pageNumber?: number
+      pageSize?: number
       paged?: boolean
       /** Format: int32 */
-      pageSize?: number
+      pageNumber?: number
       unpaged?: boolean
     }
     ReferralCaseListItem: {
@@ -3936,9 +3936,9 @@ export interface components {
       first?: boolean
       last?: boolean
       sort?: components['schemas']['SortObject']
-      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
+      pageable?: components['schemas']['PageableObject']
       empty?: boolean
     }
     GroupItem: {
@@ -4031,9 +4031,9 @@ export interface components {
       first?: boolean
       last?: boolean
       sort?: components['schemas']['SortObject']
-      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
+      pageable?: components['schemas']['PageableObject']
       empty?: boolean
     }
     /** @description Details of a Programme Group including filters and paginated group data. */
@@ -4654,7 +4654,7 @@ export interface operations {
           'application/json': components['schemas']['EditSessionDateAndTimeResponse']
         }
       }
-      /** @description Bad request - The session session duration cannot be longer than originally scheduled */
+      /** @description Bad request - For past sessions (end time has passed), the duration cannot be longer than currently scheduled */
       400: {
         headers: {
           [name: string]: unknown
@@ -5519,7 +5519,7 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          '*/*': components['schemas']['FetchPersonalDetailsResponse']
+          '*/*': components['schemas']['FetchPersonalDetailsAcceptedResponse']
         }
       }
       /** @description Bad Request */

--- a/server/editSession/dateAndTime/editSessionDateAndTimeForm.test.ts
+++ b/server/editSession/dateAndTime/editSessionDateAndTimeForm.test.ts
@@ -206,5 +206,248 @@ describe('EditSessionDateAndTimeForm', () => {
         })
       })
     })
+
+    describe('when session is in the past', () => {
+      const yesterday = new Date()
+      yesterday.setDate(yesterday.getDate() - 1)
+      const pastDate = `${yesterday.getDate()}/${yesterday.getMonth() + 1}/${yesterday.getFullYear()}`
+
+      beforeEach(() => {
+        request.body = {
+          'session-details-date': pastDate,
+          'session-details-start-time-hour': '10',
+          'session-details-start-time-minute': '0',
+          'session-details-start-time-part-of-day': 'AM',
+          'session-details-end-time-hour': '12',
+          'session-details-end-time-minute': '30',
+          'session-details-end-time-part-of-day': 'PM',
+        }
+      })
+
+      it('accepts a past date without error', async () => {
+        const data = await new EditSessionDateAndTimeFormForm(request, true).rescheduleSessionDetailsData()
+        expect(data.error).toBeNull()
+      })
+
+      it('accepts a duration equal to the original duration', async () => {
+        const originalStart = { hour: 10, minutes: 0, amOrPm: 'AM' as const }
+        const originalEnd = { hour: 12, minutes: 30, amOrPm: 'PM' as const }
+
+        request.body['session-details-start-time-hour'] = '9'
+        request.body['session-details-start-time-minute'] = '0'
+        request.body['session-details-start-time-part-of-day'] = 'AM'
+        request.body['session-details-end-time-hour'] = '11'
+        request.body['session-details-end-time-minute'] = '30'
+        request.body['session-details-end-time-part-of-day'] = 'AM'
+
+        const data = await new EditSessionDateAndTimeFormForm(
+          request,
+          true,
+          originalStart,
+          originalEnd,
+        ).rescheduleSessionDetailsData()
+        expect(data.error).toBeNull()
+      })
+
+      it('accepts a shorter duration when only start time is moved later', async () => {
+        const originalStart = { hour: 10, minutes: 0, amOrPm: 'AM' as const }
+        const originalEnd = { hour: 12, minutes: 30, amOrPm: 'PM' as const }
+
+        request.body['session-details-start-time-hour'] = '11'
+        request.body['session-details-start-time-minute'] = '0'
+        request.body['session-details-start-time-part-of-day'] = 'AM'
+        request.body['session-details-end-time-hour'] = '12'
+        request.body['session-details-end-time-minute'] = '30'
+        request.body['session-details-end-time-part-of-day'] = 'PM'
+
+        const data = await new EditSessionDateAndTimeFormForm(
+          request,
+          true,
+          originalStart,
+          originalEnd,
+        ).rescheduleSessionDetailsData()
+        expect(data.error).toBeNull()
+      })
+
+      it('accepts a shorter duration when only end time is moved earlier', async () => {
+        const originalStart = { hour: 10, minutes: 0, amOrPm: 'AM' as const }
+        const originalEnd = { hour: 12, minutes: 30, amOrPm: 'PM' as const }
+
+        request.body['session-details-start-time-hour'] = '10'
+        request.body['session-details-start-time-minute'] = '0'
+        request.body['session-details-start-time-part-of-day'] = 'AM'
+        request.body['session-details-end-time-hour'] = '12'
+        request.body['session-details-end-time-minute'] = '0'
+        request.body['session-details-end-time-part-of-day'] = 'PM'
+
+        const data = await new EditSessionDateAndTimeFormForm(
+          request,
+          true,
+          originalStart,
+          originalEnd,
+        ).rescheduleSessionDetailsData()
+        expect(data.error).toBeNull()
+      })
+
+      it('accepts a shorter duration when both start and end are changed', async () => {
+        const originalStart = { hour: 10, minutes: 0, amOrPm: 'AM' as const }
+        const originalEnd = { hour: 12, minutes: 30, amOrPm: 'PM' as const }
+
+        request.body['session-details-start-time-hour'] = '11'
+        request.body['session-details-start-time-minute'] = '0'
+        request.body['session-details-start-time-part-of-day'] = 'AM'
+        request.body['session-details-end-time-hour'] = '12'
+        request.body['session-details-end-time-minute'] = '0'
+        request.body['session-details-end-time-part-of-day'] = 'PM'
+
+        const data = await new EditSessionDateAndTimeFormForm(
+          request,
+          true,
+          originalStart,
+          originalEnd,
+        ).rescheduleSessionDetailsData()
+        expect(data.error).toBeNull()
+      })
+
+      it('returns error when submitted duration exceeds original duration', async () => {
+        const originalStart = { hour: 10, minutes: 0, amOrPm: 'AM' as const }
+        const originalEnd = { hour: 12, minutes: 30, amOrPm: 'PM' as const }
+
+        request.body['session-details-start-time-hour'] = '10'
+        request.body['session-details-start-time-minute'] = '0'
+        request.body['session-details-start-time-part-of-day'] = 'AM'
+        request.body['session-details-end-time-hour'] = '12'
+        request.body['session-details-end-time-minute'] = '31'
+        request.body['session-details-end-time-part-of-day'] = 'PM'
+
+        const data = await new EditSessionDateAndTimeFormForm(
+          request,
+          true,
+          originalStart,
+          originalEnd,
+        ).rescheduleSessionDetailsData()
+
+        expect(data.paramsForUpdate).toBeNull()
+        expect(data.error?.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              errorSummaryLinkedField: 'session-details-end-time-hour',
+              message: 'The session duration cannot be longer than originally scheduled. Change the start or end time.',
+            }),
+          ]),
+        )
+      })
+
+      it('does not check duration when session is not in the past', async () => {
+        request.body['session-details-date'] = '15/12/3055'
+        request.body['session-details-start-time-hour'] = '10'
+        request.body['session-details-start-time-minute'] = '0'
+        request.body['session-details-start-time-part-of-day'] = 'AM'
+        request.body['session-details-end-time-hour'] = '1'
+        request.body['session-details-end-time-minute'] = '0'
+        request.body['session-details-end-time-part-of-day'] = 'PM'
+
+        const data = await new EditSessionDateAndTimeFormForm(request, false).rescheduleSessionDetailsData()
+        expect(data.error).toBeNull()
+      })
+
+      it('checks duration when submitted date is past even if session flag is false', async () => {
+        const originalStart = { hour: 10, minutes: 0, amOrPm: 'AM' as const }
+        const originalEnd = { hour: 12, minutes: 30, amOrPm: 'PM' as const }
+
+        request.body['session-details-date'] = pastDate
+        request.body['session-details-start-time-hour'] = '10'
+        request.body['session-details-start-time-minute'] = '0'
+        request.body['session-details-start-time-part-of-day'] = 'AM'
+        request.body['session-details-end-time-hour'] = '12'
+        request.body['session-details-end-time-minute'] = '31'
+        request.body['session-details-end-time-part-of-day'] = 'PM'
+
+        const data = await new EditSessionDateAndTimeFormForm(
+          request,
+          false,
+          originalStart,
+          originalEnd,
+        ).rescheduleSessionDetailsData()
+
+        expect(data.error?.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              errorSummaryLinkedField: 'session-details-end-time-hour',
+              message: 'The session duration cannot be longer than originally scheduled. Change the start or end time.',
+            }),
+          ]),
+        )
+      })
+
+      describe('error shown on the correct field based on what changed', () => {
+        const originalStart = { hour: 10, minutes: 0, amOrPm: 'AM' as const }
+        const originalEnd = { hour: 12, minutes: 30, amOrPm: 'PM' as const }
+
+        beforeEach(() => {
+          request.body['session-details-date'] = pastDate
+        })
+
+        it('shows error on start time only when only start time was changed to create long duration', async () => {
+          request.body['session-details-start-time-hour'] = '9'
+          request.body['session-details-start-time-minute'] = '0'
+          request.body['session-details-start-time-part-of-day'] = 'AM'
+          request.body['session-details-end-time-hour'] = '12'
+          request.body['session-details-end-time-minute'] = '30'
+          request.body['session-details-end-time-part-of-day'] = 'PM'
+
+          const data = await new EditSessionDateAndTimeFormForm(
+            request,
+            true,
+            originalStart,
+            originalEnd,
+          ).rescheduleSessionDetailsData()
+          const fields = data.error?.errors.map(e => e.errorSummaryLinkedField) ?? []
+
+          expect(fields).toContain('session-details-start-time-hour')
+          expect(fields).not.toContain('session-details-end-time-hour')
+        })
+
+        it('shows error on end time only when only end time was changed to create long duration', async () => {
+          request.body['session-details-start-time-hour'] = '10'
+          request.body['session-details-start-time-minute'] = '0'
+          request.body['session-details-start-time-part-of-day'] = 'AM'
+          request.body['session-details-end-time-hour'] = '1'
+          request.body['session-details-end-time-minute'] = '0'
+          request.body['session-details-end-time-part-of-day'] = 'PM'
+
+          const data = await new EditSessionDateAndTimeFormForm(
+            request,
+            true,
+            originalStart,
+            originalEnd,
+          ).rescheduleSessionDetailsData()
+          const fields = data.error?.errors.map(e => e.errorSummaryLinkedField) ?? []
+
+          expect(fields).toContain('session-details-end-time-hour')
+          expect(fields).not.toContain('session-details-start-time-hour')
+        })
+
+        it('shows error on both fields when both times were changed to create long duration', async () => {
+          request.body['session-details-start-time-hour'] = '9'
+          request.body['session-details-start-time-minute'] = '0'
+          request.body['session-details-start-time-part-of-day'] = 'AM'
+          request.body['session-details-end-time-hour'] = '1'
+          request.body['session-details-end-time-minute'] = '0'
+          request.body['session-details-end-time-part-of-day'] = 'PM'
+
+          const data = await new EditSessionDateAndTimeFormForm(
+            request,
+            true,
+            originalStart,
+            originalEnd,
+          ).rescheduleSessionDetailsData()
+          const fields = data.error?.errors.map(e => e.errorSummaryLinkedField) ?? []
+
+          expect(fields).toContain('session-details-start-time-hour')
+          expect(fields).toContain('session-details-end-time-hour')
+        })
+      })
+    })
   })
 })

--- a/server/editSession/dateAndTime/editSessionDateAndTimeForm.test.ts
+++ b/server/editSession/dateAndTime/editSessionDateAndTimeForm.test.ts
@@ -205,6 +205,46 @@ describe('EditSessionDateAndTimeForm', () => {
           ],
         })
       })
+
+      it('returns error when end time is before start time', async () => {
+        request.body['session-details-start-time-hour'] = '10'
+        request.body['session-details-start-time-minute'] = '30'
+        request.body['session-details-start-time-part-of-day'] = 'AM'
+        request.body['session-details-end-time-hour'] = '9'
+        request.body['session-details-end-time-minute'] = '30'
+        request.body['session-details-end-time-part-of-day'] = 'AM'
+
+        const data = await new EditSessionDateAndTimeFormForm(request).rescheduleSessionDetailsData()
+
+        expect(data.error?.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              errorSummaryLinkedField: 'session-details-end-time-hour',
+              message: 'End time must be later than start time',
+            }),
+          ]),
+        )
+      })
+
+      it('returns error when end time is the same as start time', async () => {
+        request.body['session-details-start-time-hour'] = '10'
+        request.body['session-details-start-time-minute'] = '30'
+        request.body['session-details-start-time-part-of-day'] = 'AM'
+        request.body['session-details-end-time-hour'] = '10'
+        request.body['session-details-end-time-minute'] = '30'
+        request.body['session-details-end-time-part-of-day'] = 'AM'
+
+        const data = await new EditSessionDateAndTimeFormForm(request).rescheduleSessionDetailsData()
+
+        expect(data.error?.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              errorSummaryLinkedField: 'session-details-end-time-hour',
+              message: 'End time must be later than start time',
+            }),
+          ]),
+        )
+      })
     })
 
     describe('when session is in the past', () => {
@@ -222,6 +262,46 @@ describe('EditSessionDateAndTimeForm', () => {
           'session-details-end-time-minute': '30',
           'session-details-end-time-part-of-day': 'PM',
         }
+      })
+
+      it('returns error when end time is before start time on a past session', async () => {
+        request.body['session-details-start-time-hour'] = '10'
+        request.body['session-details-start-time-minute'] = '30'
+        request.body['session-details-start-time-part-of-day'] = 'AM'
+        request.body['session-details-end-time-hour'] = '9'
+        request.body['session-details-end-time-minute'] = '30'
+        request.body['session-details-end-time-part-of-day'] = 'AM'
+
+        const data = await new EditSessionDateAndTimeFormForm(request, true).rescheduleSessionDetailsData()
+
+        expect(data.error?.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              errorSummaryLinkedField: 'session-details-end-time-hour',
+              message: 'End time must be later than start time',
+            }),
+          ]),
+        )
+      })
+
+      it('returns error when end time equals start time on a past session', async () => {
+        request.body['session-details-start-time-hour'] = '10'
+        request.body['session-details-start-time-minute'] = '30'
+        request.body['session-details-start-time-part-of-day'] = 'AM'
+        request.body['session-details-end-time-hour'] = '10'
+        request.body['session-details-end-time-minute'] = '30'
+        request.body['session-details-end-time-part-of-day'] = 'AM'
+
+        const data = await new EditSessionDateAndTimeFormForm(request, true).rescheduleSessionDetailsData()
+
+        expect(data.error?.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              errorSummaryLinkedField: 'session-details-end-time-hour',
+              message: 'End time must be later than start time',
+            }),
+          ]),
+        )
       })
 
       it('accepts a past date without error', async () => {

--- a/server/editSession/dateAndTime/editSessionDateAndTimeForm.ts
+++ b/server/editSession/dateAndTime/editSessionDateAndTimeForm.ts
@@ -63,56 +63,23 @@ export default class EditSessionDateAndTimeFormForm {
     }
   }
 
+  private static startOrEndTimeChanged(
+    originalTime: { hour: number; minutes: number; amOrPm: 'AM' | 'PM' } | undefined,
+    submittedHour: number,
+    submittedMinute: number,
+    submittedPeriod: 'AM' | 'PM',
+  ): boolean {
+    if (!originalTime) return true
+
+    const original = DateUtils.convertTo24Hour(originalTime.hour, originalTime.minutes, originalTime.amOrPm)
+    const submitted = DateUtils.convertTo24Hour(submittedHour, submittedMinute, submittedPeriod)
+
+    return original.hour !== submitted.hour || original.minute !== submitted.minute
+  }
+
   private createSessionDetailsValidations(): ValidationChain[] {
     const { isSessionEnded } = this
-    function durationInMinutes(
-      startHour: number,
-      startMinute: number,
-      startPeriod: 'AM' | 'PM',
-      endHour: number,
-      endMinute: number,
-      endPeriod: 'AM' | 'PM',
-    ): number {
-      const start = DateUtils.convertTo24Hour(startHour, startMinute, startPeriod)
-      const end = DateUtils.convertTo24Hour(endHour, endMinute, endPeriod)
-      return end.hour * 60 + end.minute - (start.hour * 60 + start.minute)
-    }
-
-    function isTimeBefore(
-      startHour: number,
-      startMinute: number,
-      startPeriod: 'AM' | 'PM',
-      endHour: number,
-      endMinute: number,
-      endPeriod: 'AM' | 'PM',
-    ): boolean {
-      const start = DateUtils.convertTo24Hour(startHour, startMinute, startPeriod)
-      const end = DateUtils.convertTo24Hour(endHour, endMinute, endPeriod)
-
-      if (start.hour !== end.hour) {
-        return start.hour < end.hour
-      }
-      return start.minute < end.minute
-    }
     const { originalStartTime, originalEndTime } = this
-
-    function startTimeChanged(submittedHour: number, submittedMinute: number, submittedPeriod: 'AM' | 'PM'): boolean {
-      if (!originalStartTime) return true
-      const orig = DateUtils.convertTo24Hour(
-        originalStartTime.hour,
-        originalStartTime.minutes,
-        originalStartTime.amOrPm,
-      )
-      const sub = DateUtils.convertTo24Hour(submittedHour, submittedMinute, submittedPeriod)
-      return orig.hour !== sub.hour || orig.minute !== sub.minute
-    }
-
-    function endTimeChanged(submittedHour: number, submittedMinute: number, submittedPeriod: 'AM' | 'PM'): boolean {
-      if (!originalEndTime) return true
-      const orig = DateUtils.convertTo24Hour(originalEndTime.hour, originalEndTime.minutes, originalEndTime.amOrPm)
-      const sub = DateUtils.convertTo24Hour(submittedHour, submittedMinute, submittedPeriod)
-      return orig.hour !== sub.hour || orig.minute !== sub.minute
-    }
 
     /**
      * Checks if the submitted duration exceeds the original duration for a completed session.
@@ -138,10 +105,10 @@ export default class EditSessionDateAndTimeFormForm {
         return null
       }
 
-      const duration = durationInMinutes(startHour, startMinute, startPeriod, endHour, endMinute, endPeriod)
+      const duration = DateUtils.durationInMinutes(startHour, startMinute, startPeriod, endHour, endMinute, endPeriod)
       const originalDurationMinutes =
         originalStartTime && originalEndTime
-          ? durationInMinutes(
+          ? DateUtils.durationInMinutes(
               originalStartTime.hour,
               originalStartTime.minutes,
               originalStartTime.amOrPm,
@@ -155,8 +122,13 @@ export default class EditSessionDateAndTimeFormForm {
         // Only throw error if the relevant field changed
         const relevantFieldChanged =
           timeFieldThatChanged === 'start'
-            ? startTimeChanged(startHour, startMinute, startPeriod)
-            : endTimeChanged(endHour, endMinute, endPeriod)
+            ? EditSessionDateAndTimeFormForm.startOrEndTimeChanged(
+                originalStartTime,
+                startHour,
+                startMinute,
+                startPeriod,
+              )
+            : EditSessionDateAndTimeFormForm.startOrEndTimeChanged(originalEndTime, endHour, endMinute, endPeriod)
         if (relevantFieldChanged) {
           return errorMessages.sessionSchedule.sessionDetailsDurationLongerThanOriginallyScheduled
         }
@@ -292,7 +264,7 @@ export default class EditSessionDateAndTimeFormForm {
             return true
           }
 
-          if (!isTimeBefore(startHour, startMinute, startPartOfDay, endHour, endMinute, endPartOfDay)) {
+          if (!DateUtils.isTimeBefore(startHour, startMinute, startPartOfDay, endHour, endMinute, endPartOfDay)) {
             throw new Error(errorMessages.sessionSchedule.sessionDetailsEndTimeBeforeStart)
           }
           const durationError = validatePastSessionDuration(

--- a/server/editSession/dateAndTime/editSessionDateAndTimeForm.ts
+++ b/server/editSession/dateAndTime/editSessionDateAndTimeForm.ts
@@ -4,6 +4,8 @@ import { body, ValidationChain } from 'express-validator'
 import FormUtils from '../../utils/formUtils'
 import { FormData } from '../../utils/forms/formData'
 import errorMessages from '../../utils/errorMessages'
+import DateUtils from '../../utils/dateUtils'
+import DateFormatUtils from '../../utils/dateFormatUtils'
 
 const fieldOrder = [
   'session-details-date',
@@ -17,7 +19,12 @@ const fieldOrder = [
   'session-details-facilitator',
 ]
 export default class EditSessionDateAndTimeFormForm {
-  constructor(private readonly request: Request) {}
+  constructor(
+    private readonly request: Request,
+    private readonly isSessionEnded: boolean = false,
+    private readonly originalStartTime?: { hour: number; minutes: number; amOrPm: 'AM' | 'PM' },
+    private readonly originalEndTime?: { hour: number; minutes: number; amOrPm: 'AM' | 'PM' },
+  ) {}
 
   async rescheduleSessionDetailsData(): Promise<FormData<Partial<RescheduleSessionRequest>>> {
     const validationResult = await FormUtils.runValidations({
@@ -57,14 +64,18 @@ export default class EditSessionDateAndTimeFormForm {
   }
 
   private createSessionDetailsValidations(): ValidationChain[] {
-    function convertTo24Hour(hour: number, minute: number, period: 'AM' | 'PM'): { hour: number; minute: number } {
-      let hour24 = hour
-      if (period === 'AM') {
-        hour24 = hour === 12 ? 0 : hour // 12 AM is midnight (0), other AM hours stay the same
-      } else {
-        hour24 = hour === 12 ? 12 : hour + 12 // 12 PM stays 12, other PM hours add 12
-      }
-      return { hour: hour24, minute }
+    const { isSessionEnded } = this
+    function durationInMinutes(
+      startHour: number,
+      startMinute: number,
+      startPeriod: 'AM' | 'PM',
+      endHour: number,
+      endMinute: number,
+      endPeriod: 'AM' | 'PM',
+    ): number {
+      const start = DateUtils.convertTo24Hour(startHour, startMinute, startPeriod)
+      const end = DateUtils.convertTo24Hour(endHour, endMinute, endPeriod)
+      return end.hour * 60 + end.minute - (start.hour * 60 + start.minute)
     }
 
     function isTimeBefore(
@@ -75,38 +86,159 @@ export default class EditSessionDateAndTimeFormForm {
       endMinute: number,
       endPeriod: 'AM' | 'PM',
     ): boolean {
-      const start = convertTo24Hour(startHour, startMinute, startPeriod)
-      const end = convertTo24Hour(endHour, endMinute, endPeriod)
+      const start = DateUtils.convertTo24Hour(startHour, startMinute, startPeriod)
+      const end = DateUtils.convertTo24Hour(endHour, endMinute, endPeriod)
 
       if (start.hour !== end.hour) {
         return start.hour < end.hour
       }
       return start.minute < end.minute
     }
+    const { originalStartTime, originalEndTime } = this
+
+    function startTimeChanged(submittedHour: number, submittedMinute: number, submittedPeriod: 'AM' | 'PM'): boolean {
+      if (!originalStartTime) return true
+      const orig = DateUtils.convertTo24Hour(
+        originalStartTime.hour,
+        originalStartTime.minutes,
+        originalStartTime.amOrPm,
+      )
+      const sub = DateUtils.convertTo24Hour(submittedHour, submittedMinute, submittedPeriod)
+      return orig.hour !== sub.hour || orig.minute !== sub.minute
+    }
+
+    function endTimeChanged(submittedHour: number, submittedMinute: number, submittedPeriod: 'AM' | 'PM'): boolean {
+      if (!originalEndTime) return true
+      const orig = DateUtils.convertTo24Hour(originalEndTime.hour, originalEndTime.minutes, originalEndTime.amOrPm)
+      const sub = DateUtils.convertTo24Hour(submittedHour, submittedMinute, submittedPeriod)
+      return orig.hour !== sub.hour || orig.minute !== sub.minute
+    }
+
+    /**
+     * Checks if the submitted duration exceeds the original duration for a completed session.
+     * Returns error message if validation should throw, or null if valid.
+     */
+    function validatePastSessionDuration(
+      dateStr: string,
+      startHour: number,
+      startMinute: number,
+      startPeriod: 'AM' | 'PM',
+      endHour: number,
+      endMinute: number,
+      endPeriod: 'AM' | 'PM',
+      timeFieldThatChanged: 'start' | 'end',
+    ): string | null {
+      // Check if the session has ended (using end time)
+      const shouldValidatePastDuration =
+        isSessionEnded ||
+        DateFormatUtils.isDateInPast(dateStr) ||
+        DateFormatUtils.isSessionEnded(dateStr, endHour, endMinute, endPeriod)
+
+      if (!shouldValidatePastDuration) {
+        return null
+      }
+
+      const duration = durationInMinutes(startHour, startMinute, startPeriod, endHour, endMinute, endPeriod)
+      const originalDurationMinutes =
+        originalStartTime && originalEndTime
+          ? durationInMinutes(
+              originalStartTime.hour,
+              originalStartTime.minutes,
+              originalStartTime.amOrPm,
+              originalEndTime.hour,
+              originalEndTime.minutes,
+              originalEndTime.amOrPm,
+            )
+          : null
+
+      if (originalDurationMinutes !== null && duration > originalDurationMinutes) {
+        // Only throw error if the relevant field changed
+        const relevantFieldChanged =
+          timeFieldThatChanged === 'start'
+            ? startTimeChanged(startHour, startMinute, startPeriod)
+            : endTimeChanged(endHour, endMinute, endPeriod)
+        if (relevantFieldChanged) {
+          return errorMessages.sessionSchedule.sessionDetailsDurationLongerThanOriginallyScheduled
+        }
+      }
+
+      return null
+    }
+
+    const dateValidation = body('session-details-date')
+      .notEmpty()
+      .withMessage(errorMessages.sessionSchedule.sessionDetailsDate)
+      .bail()
+      .matches(/^(0?[1-9]|[12]\d|3[01])\/(0?[1-9]|1[0-2])\/\d{4}$/)
+      .withMessage(errorMessages.sessionSchedule.sessionDetailsDateInvalid)
+
+    // Only prevent past dates if the session hasn't ended
+    if (!isSessionEnded) {
+      dateValidation.bail().custom((value: string) => {
+        if (DateFormatUtils.isDateInPast(value)) {
+          throw new Error(errorMessages.sessionSchedule.sessionDetailsDateInPast)
+        }
+        return true
+      })
+    }
+
     return [
-      body('session-details-date')
-        .notEmpty()
-        .withMessage(errorMessages.sessionSchedule.sessionDetailsDate)
-        .bail()
-        .matches(/^(0?[1-9]|[12]\d|3[01])\/(0?[1-9]|1[0-2])\/\d{4}$/)
-        .withMessage(errorMessages.sessionSchedule.sessionDetailsDateInvalid)
-        .bail()
-        .custom((value: string) => {
-          const [day, month, year] = value.split('/').map(Number)
-          const inputDate = new Date(year, month - 1, day)
-          const today = new Date()
-          today.setHours(0, 0, 0, 0)
-          if (inputDate < today) {
-            throw new Error(errorMessages.sessionSchedule.sessionDetailsDateInPast)
-          }
-          return true
-        }),
+      dateValidation,
+
       body(`session-details-start-time-hour`)
         .notEmpty()
         .withMessage(errorMessages.sessionSchedule.sessionDetailsStartTime)
         .bail()
         .isInt({ min: 1, max: 12 })
-        .withMessage(errorMessages.sessionSchedule.sessionDetailsTimeHour),
+        .withMessage(errorMessages.sessionSchedule.sessionDetailsTimeHour)
+        .if(body('session-details-end-time-hour').notEmpty())
+        .custom((startHourValue, { req }) => {
+          const startHour = parseInt(startHourValue, 10)
+          const startMinuteValue = req.body['session-details-start-time-minute']
+          const startMinute = parseInt(startMinuteValue, 10)
+          const startPartOfDay = req.body['session-details-start-time-part-of-day']
+
+          const endHourValue = req.body['session-details-end-time-hour']
+          const endHour = parseInt(endHourValue, 10)
+          const endMinuteValue = req.body['session-details-end-time-minute']
+          const endMinute = parseInt(endMinuteValue, 10)
+          const endPartOfDay = req.body['session-details-end-time-part-of-day']
+
+          if (
+            Number.isNaN(startHour) ||
+            startHour < 1 ||
+            startHour > 12 ||
+            !startPartOfDay ||
+            Number.isNaN(startMinute) ||
+            startMinute < 0 ||
+            startMinute > 59 ||
+            Number.isNaN(endHour) ||
+            endHour < 1 ||
+            endHour > 12 ||
+            !endPartOfDay ||
+            Number.isNaN(endMinute) ||
+            endMinute < 0 ||
+            endMinute > 59
+          ) {
+            return true
+          }
+
+          const durationError = validatePastSessionDuration(
+            req.body['session-details-date'],
+            startHour,
+            startMinute,
+            startPartOfDay,
+            endHour,
+            endMinute,
+            endPartOfDay,
+            'start',
+          )
+          if (durationError) {
+            throw new Error(durationError)
+          }
+
+          return true
+        }),
       body(`session-details-start-time-minute`)
         .if(body('session-details-start-time-hour').notEmpty())
         .isInt({ min: 0, max: 59 })
@@ -120,23 +252,61 @@ export default class EditSessionDateAndTimeFormForm {
         .bail()
         .isInt({ min: 1, max: 12 })
         .withMessage(errorMessages.sessionSchedule.sessionDetailsTimeHour)
+        .bail()
         .if(body('session-details-start-time-hour').notEmpty())
         .custom((endHourValue, { req }) => {
-          const startHour = parseInt(req.body['session-details-start-time-hour'], 10)
-          const startMinute = parseInt(req.body['session-details-start-time-minute'] || '0', 10)
+          const startHourValue = req.body['session-details-start-time-hour']
+          const startHour = parseInt(startHourValue, 10)
+          const startMinuteValue = req.body['session-details-start-time-minute']
+          const startMinute = parseInt(startMinuteValue, 10)
           const startPartOfDay = req.body['session-details-start-time-part-of-day']
 
           const endHour = parseInt(endHourValue, 10)
-          const endMinute = parseInt(req.body['session-details-end-time-minute'] || '0', 10)
+          const endMinuteValue = req.body['session-details-end-time-minute']
+          const endMinute = parseInt(endMinuteValue, 10)
           const endPartOfDay = req.body['session-details-end-time-part-of-day']
 
-          if (!startHour || !startPartOfDay || startHour < 1 || startHour > 12 || startMinute < 0 || startMinute > 59) {
+          if (
+            Number.isNaN(startHour) ||
+            startHour < 1 ||
+            startHour > 12 ||
+            !startPartOfDay ||
+            Number.isNaN(startMinute) ||
+            startMinute < 0 ||
+            startMinute > 59
+          ) {
             // Skip validation if start time is invalid
+            return true
+          }
+
+          if (
+            Number.isNaN(endHour) ||
+            endHour < 1 ||
+            endHour > 12 ||
+            !endPartOfDay ||
+            Number.isNaN(endMinute) ||
+            endMinute < 0 ||
+            endMinute > 59
+          ) {
+            // Skip cross-field validation if end time is invalid or incomplete
             return true
           }
 
           if (!isTimeBefore(startHour, startMinute, startPartOfDay, endHour, endMinute, endPartOfDay)) {
             throw new Error(errorMessages.sessionSchedule.sessionDetailsEndTimeBeforeStart)
+          }
+          const durationError = validatePastSessionDuration(
+            req.body['session-details-date'],
+            startHour,
+            startMinute,
+            startPartOfDay,
+            endHour,
+            endMinute,
+            endPartOfDay,
+            'end',
+          )
+          if (durationError) {
+            throw new Error(durationError)
           }
           return true
         }),

--- a/server/editSession/editSessionController.test.ts
+++ b/server/editSession/editSessionController.test.ts
@@ -163,7 +163,9 @@ describe('editSessionDateAndTime', () => {
 
   describe('POST /:groupId/:sessionId/edit-session-date-and-time', () => {
     it('should fetch session details with correct parameters and load page correctly', async () => {
-      const sessionDetails = editSessionDetailsFactory.build()
+      const sessionDetails = editSessionDetailsFactory.build({
+        sessionDate: '3055-12-01',
+      })
       const sessionAttendees = editSessionAttendeesFactory.build({ sessionType: 'GROUP' })
       accreditedProgrammesManageAndDeliverService.getSessionEditDateAndTime.mockResolvedValue(sessionDetails)
       accreditedProgrammesManageAndDeliverService.getSessionAttendees.mockResolvedValue(sessionAttendees)
@@ -183,6 +185,156 @@ describe('editSessionDateAndTime', () => {
         .expect(302)
         .expect(res => {
           expect(res.text).toContain(`Redirecting to /111/6789/edit-group-days-and-times/reschedule`)
+        })
+    })
+
+    it('should submit directly for a past group session instead of redirecting to reschedule later sessions', async () => {
+      const sessionDetails = editSessionDetailsFactory.build({
+        sessionDate: '2000-01-01',
+        sessionStartTime: { hour: 10, minutes: 0, amOrPm: 'AM' },
+        sessionEndTime: { hour: 12, minutes: 30, amOrPm: 'PM' },
+      })
+      const sessionAttendees = editSessionAttendeesFactory.build({ sessionType: 'GROUP', isCatchup: false })
+      accreditedProgrammesManageAndDeliverService.getSessionEditDateAndTime.mockResolvedValue(sessionDetails)
+      accreditedProgrammesManageAndDeliverService.getSessionAttendees.mockResolvedValue(sessionAttendees)
+      accreditedProgrammesManageAndDeliverService.updateSessionDateAndTime.mockResolvedValue({
+        message: 'Test message',
+      })
+
+      await request(app)
+        .post(`/111/6789/edit-session-date-and-time`)
+        .type('form')
+        .send({
+          'session-details-date': '1/1/2000',
+          'session-details-start-time-hour': '9',
+          'session-details-start-time-minute': '0',
+          'session-details-start-time-part-of-day': 'AM',
+          'session-details-end-time-hour': '11',
+          'session-details-end-time-minute': '30',
+          'session-details-end-time-part-of-day': 'AM',
+        })
+        .expect(302)
+        .expect('Location', '/111/6789/edit-session?message=Test%20message')
+
+      expect(accreditedProgrammesManageAndDeliverService.updateSessionDateAndTime).toHaveBeenCalledWith(
+        'user1',
+        '6789',
+        {
+          sessionStartDate: '2000-01-01',
+          sessionStartTime: { hour: 9, minutes: 0, amOrPm: 'AM' },
+          sessionEndTime: { hour: 11, minutes: 30, amOrPm: 'AM' },
+          rescheduleOtherSessions: false,
+        },
+      )
+    })
+
+    it('should return validation error if a past session is made longer than originally scheduled', async () => {
+      const sessionDetails = editSessionDetailsFactory.build({
+        sessionDate: '2000-01-01',
+        sessionStartTime: { hour: 10, minutes: 0, amOrPm: 'AM' },
+        sessionEndTime: { hour: 12, minutes: 30, amOrPm: 'PM' },
+      })
+      const sessionAttendees = editSessionAttendeesFactory.build({ sessionType: 'GROUP' })
+      accreditedProgrammesManageAndDeliverService.getSessionEditDateAndTime.mockResolvedValue(sessionDetails)
+      accreditedProgrammesManageAndDeliverService.getSessionAttendees.mockResolvedValue(sessionAttendees)
+
+      await request(app)
+        .post(`/111/6789/edit-session-date-and-time`)
+        .type('form')
+        .send({
+          'session-details-date': '1/1/2000',
+          'session-details-start-time-hour': '10',
+          'session-details-start-time-minute': '0',
+          'session-details-start-time-part-of-day': 'AM',
+          'session-details-end-time-hour': '12',
+          'session-details-end-time-minute': '31',
+          'session-details-end-time-part-of-day': 'PM',
+        })
+        .expect(400)
+        .expect(res => {
+          expect(res.text).toContain(
+            'The session duration cannot be longer than originally scheduled. Change the start or end time.',
+          )
+        })
+
+      expect(accreditedProgrammesManageAndDeliverService.updateSessionDateAndTime).not.toHaveBeenCalled()
+    })
+
+    it('should map API 400 duration error to a field validation error instead of generic bad request', async () => {
+      const sessionDetails = editSessionDetailsFactory.build({
+        sessionDate: '2000-01-01',
+        sessionStartTime: { hour: 10, minutes: 0, amOrPm: 'AM' },
+        sessionEndTime: { hour: 12, minutes: 30, amOrPm: 'PM' },
+      })
+      const sessionAttendees = editSessionAttendeesFactory.build({ sessionType: 'GROUP', isCatchup: false })
+      accreditedProgrammesManageAndDeliverService.getSessionEditDateAndTime.mockResolvedValue(sessionDetails)
+      accreditedProgrammesManageAndDeliverService.getSessionAttendees.mockResolvedValue(sessionAttendees)
+      accreditedProgrammesManageAndDeliverService.updateSessionDateAndTime.mockRejectedValue(
+        Object.assign(new Error('Bad Request'), {
+          status: 400,
+          data: {
+            userMessage:
+              'The session duration cannot be longer than originally scheduled. Change the start or end time.',
+          },
+        }),
+      )
+
+      await request(app)
+        .post(`/111/6789/edit-session-date-and-time`)
+        .type('form')
+        .send({
+          'session-details-date': '1/1/2000',
+          'session-details-start-time-hour': '9',
+          'session-details-start-time-minute': '0',
+          'session-details-start-time-part-of-day': 'AM',
+          'session-details-end-time-hour': '11',
+          'session-details-end-time-minute': '30',
+          'session-details-end-time-part-of-day': 'AM',
+        })
+        .expect(400)
+        .expect(res => {
+          expect(res.text).toContain(
+            'The session duration cannot be longer than originally scheduled. Change the start or end time.',
+          )
+        })
+    })
+
+    it('should show an explanatory message when submitted duration is shorter than current but still rejected by API', async () => {
+      const sessionDetails = editSessionDetailsFactory.build({
+        sessionDate: '2000-01-01',
+        sessionStartTime: { hour: 3, minutes: 51, amOrPm: 'PM' },
+        sessionEndTime: { hour: 3, minutes: 59, amOrPm: 'PM' },
+      })
+      const sessionAttendees = editSessionAttendeesFactory.build({ sessionType: 'GROUP', isCatchup: false })
+      accreditedProgrammesManageAndDeliverService.getSessionEditDateAndTime.mockResolvedValue(sessionDetails)
+      accreditedProgrammesManageAndDeliverService.getSessionAttendees.mockResolvedValue(sessionAttendees)
+      accreditedProgrammesManageAndDeliverService.updateSessionDateAndTime.mockRejectedValue(
+        Object.assign(new Error('Bad Request'), {
+          status: 400,
+          data: {
+            userMessage:
+              'Bad request: The session session duration cannot be longer than originally scheduled. Change the start or end time.',
+          },
+        }),
+      )
+
+      await request(app)
+        .post(`/111/6789/edit-session-date-and-time`)
+        .type('form')
+        .send({
+          'session-details-date': '1/1/2000',
+          'session-details-start-time-hour': '3',
+          'session-details-start-time-minute': '51',
+          'session-details-start-time-part-of-day': 'PM',
+          'session-details-end-time-hour': '3',
+          'session-details-end-time-minute': '58',
+          'session-details-end-time-part-of-day': 'PM',
+        })
+        .expect(400)
+        .expect(res => {
+          expect(res.text).toContain(
+            'You have shortened this session, but it is still longer than the originally scheduled duration.',
+          )
         })
     })
   })

--- a/server/editSession/editSessionController.test.ts
+++ b/server/editSession/editSessionController.test.ts
@@ -313,7 +313,7 @@ describe('editSessionDateAndTime', () => {
           status: 400,
           data: {
             userMessage:
-              'Bad request: The session session duration cannot be longer than originally scheduled. Change the start or end time.',
+              'The session duration cannot be longer than originally scheduled. Change the start or end time.',
           },
         }),
       )

--- a/server/editSession/editSessionController.ts
+++ b/server/editSession/editSessionController.ts
@@ -21,6 +21,7 @@ import EditSessionFacilitatorsView from './facilitators/editSessionFacilitatorsV
 import BaseController from '../shared/baseController'
 import { PrimaryNavigationTab } from '../shared/routes/layoutPresenter'
 import { convertToUrlFriendlyKebabCase, getEditSessionRouteTitle } from '../utils/utils'
+import DateUtils from '../utils/dateUtils'
 import DateFormatUtils from '../utils/dateFormatUtils'
 import errorMessages from '../utils/errorMessages'
 
@@ -121,13 +122,8 @@ export default class EditSessionController extends BaseController {
   }
 
   private static durationInMinutes(time: { hour: number; minutes: number; amOrPm: 'AM' | 'PM' }): number {
-    let hour24: number
-    if (time.amOrPm === 'AM') {
-      hour24 = time.hour === 12 ? 0 : time.hour
-    } else {
-      hour24 = time.hour === 12 ? 12 : time.hour + 12
-    }
-    return hour24 * 60 + time.minutes
+    const convertedTime = DateUtils.convertTo24Hour(time.hour, time.minutes, time.amOrPm)
+    return convertedTime.hour * 60 + convertedTime.minute
   }
 
   private static isSubmittedDurationShorterThanCurrent(

--- a/server/editSession/editSessionController.ts
+++ b/server/editSession/editSessionController.ts
@@ -100,10 +100,9 @@ export default class EditSessionController extends BaseController {
       return null
     }
 
-    const messageCandidates = [data.userMessage, data.developerMessage]
-    const matchedMessage = messageCandidates.find(
-      candidate =>
-        typeof candidate === 'string' && candidate.toLowerCase().includes('cannot be longer than originally scheduled'),
+    const messageUsers = [data.userMessage, data.developerMessage]
+    const matchedMessage = messageUsers.find(
+      user => typeof user === 'string' && user.toLowerCase().includes('cannot be longer than originally scheduled'),
     )
 
     if (!matchedMessage) {

--- a/server/editSession/editSessionController.ts
+++ b/server/editSession/editSessionController.ts
@@ -21,14 +21,137 @@ import EditSessionFacilitatorsView from './facilitators/editSessionFacilitatorsV
 import BaseController from '../shared/baseController'
 import { PrimaryNavigationTab } from '../shared/routes/layoutPresenter'
 import { convertToUrlFriendlyKebabCase, getEditSessionRouteTitle } from '../utils/utils'
+import DateFormatUtils from '../utils/dateFormatUtils'
+import errorMessages from '../utils/errorMessages'
 
 export default class EditSessionController extends BaseController {
   protected readonly primaryNavigationTab = PrimaryNavigationTab.Groups
+
+  private static readonly durationLongerThanOriginallyScheduledErrorMessage =
+    errorMessages.sessionSchedule.sessionDetailsDurationLongerThanOriginallyScheduled
 
   constructor(
     private readonly accreditedProgrammesManageAndDeliverService: AccreditedProgrammesManageAndDeliverService,
   ) {
     super()
+  }
+
+  /**
+   * Convert a date string to YYYY-MM-DD (date-only format).
+   * Accepts ISO with or without time, or UK format (DD/MM/YYYY).
+   */
+  private static toDateOnlyString(dateStr: string): string | null {
+    return DateFormatUtils.toDateOnlyISO(dateStr)
+  }
+
+  private static hasSessionDateAndTimeChanged(
+    sessionDetails: {
+      sessionDate: string
+      sessionStartTime: { hour: number; minutes: number; amOrPm: 'AM' | 'PM' }
+      sessionEndTime: { hour: number; minutes: number; amOrPm: 'AM' | 'PM' }
+    },
+    submitted: {
+      sessionStartDate: string // DD/MM/YYYY
+      sessionStartTime: { hour: number; minutes: number; amOrPm: 'AM' | 'PM' }
+      sessionEndTime: { hour: number; minutes: number; amOrPm: 'AM' | 'PM' }
+    },
+  ): boolean {
+    const sessionDateForComparison = EditSessionController.toDateOnlyString(sessionDetails.sessionDate)
+    const submittedDateForComparison = EditSessionController.toDateOnlyString(submitted.sessionStartDate)
+    if (sessionDateForComparison !== submittedDateForComparison) return true
+
+    const origStart = sessionDetails.sessionStartTime
+    const subStart = submitted.sessionStartTime
+    if (
+      origStart.hour !== subStart.hour ||
+      origStart.minutes !== subStart.minutes ||
+      origStart.amOrPm !== subStart.amOrPm
+    )
+      return true
+
+    const origEnd = sessionDetails.sessionEndTime
+    const subEnd = submitted.sessionEndTime
+    if (origEnd.hour !== subEnd.hour || origEnd.minutes !== subEnd.minutes || origEnd.amOrPm !== subEnd.amOrPm)
+      return true
+
+    return false
+  }
+
+  private isSessionEnded(sessionDetails: {
+    sessionDate: string
+    sessionEndTime: { hour: number; minutes: number; amOrPm: 'AM' | 'PM' }
+  }): boolean {
+    return DateFormatUtils.isSessionEnded(
+      sessionDetails.sessionDate,
+      sessionDetails.sessionEndTime.hour,
+      sessionDetails.sessionEndTime.minutes,
+      sessionDetails.sessionEndTime.amOrPm,
+    )
+  }
+
+  private static toDurationValidationError(error: unknown): FormValidationError | null {
+    const status = typeof error === 'object' && error !== null ? (error as { status?: number }).status : undefined
+    const data =
+      typeof error === 'object' && error !== null
+        ? (error as { data?: { userMessage?: unknown; developerMessage?: unknown } }).data
+        : undefined
+
+    if (status !== 400 || !data) {
+      return null
+    }
+
+    const messageCandidates = [data.userMessage, data.developerMessage]
+    const matchedMessage = messageCandidates.find(
+      candidate =>
+        typeof candidate === 'string' && candidate.toLowerCase().includes('cannot be longer than originally scheduled'),
+    )
+
+    if (!matchedMessage) {
+      return null
+    }
+
+    return {
+      errors: [
+        {
+          errorSummaryLinkedField: 'session-details-end-time-hour',
+          formFields: ['session-details-end-time-hour'],
+          message:
+            typeof matchedMessage === 'string'
+              ? matchedMessage
+              : EditSessionController.durationLongerThanOriginallyScheduledErrorMessage,
+        },
+      ],
+    }
+  }
+
+  private static durationInMinutes(time: { hour: number; minutes: number; amOrPm: 'AM' | 'PM' }): number {
+    let hour24: number
+    if (time.amOrPm === 'AM') {
+      hour24 = time.hour === 12 ? 0 : time.hour
+    } else {
+      hour24 = time.hour === 12 ? 12 : time.hour + 12
+    }
+    return hour24 * 60 + time.minutes
+  }
+
+  private static isSubmittedDurationShorterThanCurrent(
+    sessionDetails: {
+      sessionStartTime: { hour: number; minutes: number; amOrPm: 'AM' | 'PM' }
+      sessionEndTime: { hour: number; minutes: number; amOrPm: 'AM' | 'PM' }
+    },
+    submitted: {
+      sessionStartTime: { hour: number; minutes: number; amOrPm: 'AM' | 'PM' }
+      sessionEndTime: { hour: number; minutes: number; amOrPm: 'AM' | 'PM' }
+    },
+  ): boolean {
+    const currentDuration =
+      EditSessionController.durationInMinutes(sessionDetails.sessionEndTime) -
+      EditSessionController.durationInMinutes(sessionDetails.sessionStartTime)
+    const submittedDuration =
+      EditSessionController.durationInMinutes(submitted.sessionEndTime) -
+      EditSessionController.durationInMinutes(submitted.sessionStartTime)
+
+    return submittedDuration < currentDuration
   }
 
   async editSession(req: Request, res: Response): Promise<void> {
@@ -153,26 +276,43 @@ export default class EditSessionController extends BaseController {
       username,
       sessionId,
     )
+    const isSessionEnded = this.isSessionEnded(sessionDetails)
     const sessionAttendees = await this.accreditedProgrammesManageAndDeliverService.getSessionAttendees(
       username,
       sessionId,
     )
 
     if (req.method === 'POST') {
-      const data = await new EditSessionDateAndTimeFormForm(req).rescheduleSessionDetailsData()
+      const data = await new EditSessionDateAndTimeFormForm(
+        req,
+        isSessionEnded,
+        sessionDetails.sessionStartTime,
+        sessionDetails.sessionEndTime,
+      ).rescheduleSessionDetailsData()
       if (data.error) {
         res.status(400)
         formError = data.error
         userInputData = req.body
       } else {
+        const { sessionStartDate, sessionStartTime, sessionEndTime } = data.paramsForUpdate
+        const hasChanged = EditSessionController.hasSessionDateAndTimeChanged(sessionDetails, {
+          sessionStartDate,
+          sessionStartTime,
+          sessionEndTime,
+        })
+
+        if (!hasChanged) {
+          return res.redirect(`/${groupId}/${sessionId}/edit-session`)
+        }
         req.session.editSessionDateAndTime = {
           sessionStartDate: data.paramsForUpdate.sessionStartDate,
           sessionStartTime: data.paramsForUpdate.sessionStartTime,
           sessionEndTime: data.paramsForUpdate.sessionEndTime,
         }
 
-        // GROUP sessions and ONE_TO_ONE catch-ups go to the reschedule page
-        if (sessionAttendees.sessionType === 'GROUP' && !sessionAttendees.isCatchup) {
+        // GROUP sessions that have not yet ended go to the reschedule page.
+        // Ended sessions submit directly so users are not asked to reschedule later sessions.
+        if (sessionAttendees.sessionType === 'GROUP' && !sessionAttendees.isCatchup && !isSessionEnded) {
           return res.redirect(`/${groupId}/${sessionId}/edit-group-days-and-times/reschedule`)
         }
 
@@ -187,11 +327,47 @@ export default class EditSessionController extends BaseController {
           rescheduleOtherSessions: false,
         }
 
-        const response = await this.accreditedProgrammesManageAndDeliverService.updateSessionDateAndTime(
-          username,
-          sessionId,
-          rescheduleRequest,
-        )
+        let response: { message: string } | null
+        try {
+          response = await this.accreditedProgrammesManageAndDeliverService.updateSessionDateAndTime(
+            username,
+            sessionId,
+            rescheduleRequest,
+          )
+        } catch (error) {
+          const durationValidationError = EditSessionController.toDurationValidationError(error)
+          if (!durationValidationError) {
+            throw error
+          }
+
+          if (
+            EditSessionController.isSubmittedDurationShorterThanCurrent(sessionDetails, {
+              sessionStartTime: rescheduleRequest.sessionStartTime,
+              sessionEndTime: rescheduleRequest.sessionEndTime,
+            })
+          ) {
+            durationValidationError.errors[0].message = `${durationValidationError.errors[0].message} You have shortened this session, but it is still longer than the originally scheduled duration.`
+          }
+
+          res.status(400)
+          formError = durationValidationError
+          userInputData = req.body
+          response = null
+        }
+
+        if (!response) {
+          const presenter = new EditSessionDateAndTimePresenter(
+            groupId,
+            sessionDetails,
+            sessionAttendees.sessionType,
+            req.session.editSessionDateAndTime,
+            formError,
+            userInputData,
+          )
+          const view = new EditSessionDateAndTimeView(presenter)
+
+          return this.renderPage(res, view)
+        }
 
         delete req.session.editSessionDateAndTime
 

--- a/server/editSession/editSessionController.ts
+++ b/server/editSession/editSessionController.ts
@@ -115,10 +115,7 @@ export default class EditSessionController extends BaseController {
         {
           errorSummaryLinkedField: 'session-details-end-time-hour',
           formFields: ['session-details-end-time-hour'],
-          message:
-            typeof matchedMessage === 'string'
-              ? matchedMessage
-              : EditSessionController.durationLongerThanOriginallyScheduledErrorMessage,
+          message: EditSessionController.durationLongerThanOriginallyScheduledErrorMessage,
         },
       ],
     }

--- a/server/utils/dateFormatUtils.test.ts
+++ b/server/utils/dateFormatUtils.test.ts
@@ -1,0 +1,154 @@
+import DateFormatUtils from './dateFormatUtils'
+
+describe('DateFormatUtils', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date(2026, 6, 6, 12, 0, 0, 0))
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  describe('parseUKDateToDate', () => {
+    it('parses valid UK date format', () => {
+      const result = DateFormatUtils.parseUKDateToDate('15/03/2021')
+      expect(result).toEqual(new Date(2021, 2, 15, 0, 0, 0, 0))
+    })
+
+    it('handles single digit day and month', () => {
+      const result = DateFormatUtils.parseUKDateToDate('5/3/2021')
+      expect(result).toEqual(new Date(2021, 2, 5, 0, 0, 0, 0))
+    })
+
+    it('returns null for non-string input', () => {
+      expect(DateFormatUtils.parseUKDateToDate(null as unknown as string)).toBeNull()
+      expect(DateFormatUtils.parseUKDateToDate(123 as unknown as string)).toBeNull()
+    })
+
+    it('returns null for invalid format', () => {
+      expect(DateFormatUtils.parseUKDateToDate('2021-03-15')).toBeNull()
+      expect(DateFormatUtils.parseUKDateToDate('invalid')).toBeNull()
+    })
+  })
+
+  describe('parseISODateToDate', () => {
+    it('parses valid ISO date format', () => {
+      const result = DateFormatUtils.parseISODateToDate('2021-03-15')
+      expect(result).toEqual(new Date(2021, 2, 15, 0, 0, 0, 0))
+    })
+
+    it('handles ISO format with time component', () => {
+      const result = DateFormatUtils.parseISODateToDate('2021-03-15T10:30:00')
+      expect(result).toEqual(new Date(2021, 2, 15, 0, 0, 0, 0))
+    })
+
+    it('handles API timestamps with a space separator', () => {
+      const result = DateFormatUtils.parseISODateToDate('2026-07-06 13:00:00.000000')
+      expect(result).toEqual(new Date(2026, 6, 6, 0, 0, 0, 0))
+    })
+
+    it('returns null for non-string input', () => {
+      expect(DateFormatUtils.parseISODateToDate(null as unknown as string)).toBeNull()
+    })
+
+    it('returns null for invalid format', () => {
+      expect(DateFormatUtils.parseISODateToDate('15/03/2021')).toBeNull()
+    })
+  })
+
+  describe('parseDate', () => {
+    it('parses UK date format', () => {
+      const result = DateFormatUtils.parseDate('15/03/2021')
+      expect(result).toEqual(new Date(2021, 2, 15, 0, 0, 0, 0))
+    })
+
+    it('parses ISO date format', () => {
+      const result = DateFormatUtils.parseDate('2021-03-15')
+      expect(result).toEqual(new Date(2021, 2, 15, 0, 0, 0, 0))
+    })
+
+    it('returns null if format is unrecognized', () => {
+      expect(DateFormatUtils.parseDate('invalid')).toBeNull()
+    })
+  })
+
+  describe('toDateOnlyISO', () => {
+    it('converts UK date to ISO format', () => {
+      expect(DateFormatUtils.toDateOnlyISO('15/03/2021')).toEqual('2021-03-15')
+    })
+
+    it('normalizes ISO date', () => {
+      expect(DateFormatUtils.toDateOnlyISO('2021-03-15')).toEqual('2021-03-15')
+    })
+
+    it('handles ISO with time component', () => {
+      expect(DateFormatUtils.toDateOnlyISO('2021-03-15T10:30:00')).toEqual('2021-03-15')
+    })
+
+    it('handles API timestamps with a space separator', () => {
+      expect(DateFormatUtils.toDateOnlyISO('2026-07-06 13:00:00.000000')).toEqual('2026-07-06')
+    })
+
+    it('returns null for invalid formats', () => {
+      expect(DateFormatUtils.toDateOnlyISO('invalid')).toBeNull()
+      expect(DateFormatUtils.toDateOnlyISO('')).toBeNull()
+    })
+  })
+
+  describe('isDateInPast', () => {
+    it('returns true for past dates', () => {
+      expect(DateFormatUtils.isDateInPast('5/7/2026')).toBe(true)
+    })
+
+    it('returns false for today', () => {
+      expect(DateFormatUtils.isDateInPast('6/7/2026')).toBe(false)
+    })
+
+    it('returns false for future dates', () => {
+      expect(DateFormatUtils.isDateInPast('7/7/2026')).toBe(false)
+    })
+  })
+
+  describe('isDateToday', () => {
+    it('returns true for today', () => {
+      expect(DateFormatUtils.isDateToday('6/7/2026')).toBe(true)
+    })
+
+    it('returns false for past dates', () => {
+      expect(DateFormatUtils.isDateToday('5/7/2026')).toBe(false)
+    })
+
+    it('returns false for future dates', () => {
+      expect(DateFormatUtils.isDateToday('7/7/2026')).toBe(false)
+    })
+  })
+
+  describe('hasTimePassedOnDate', () => {
+    it('returns false if date is not today', () => {
+      expect(DateFormatUtils.hasTimePassedOnDate('7/7/2026', 10, 0, 'AM')).toBe(false)
+    })
+
+    it('supports ISO timestamps for today', () => {
+      expect(DateFormatUtils.hasTimePassedOnDate('2026-07-06 23:00:00.000000', 11, 59, 'PM')).toBe(false)
+    })
+
+    it('returns true if time has passed on today', () => {
+      expect(DateFormatUtils.hasTimePassedOnDate('6/7/2026', 11, 59, 'AM')).toBe(true)
+    })
+  })
+
+  describe('isSessionInPast', () => {
+    it('returns true for past sessions', () => {
+      expect(DateFormatUtils.isSessionInPast('5/7/2026', 10, 0, 'AM')).toBe(true)
+    })
+
+    it('returns false for future sessions', () => {
+      expect(DateFormatUtils.isSessionInPast('7/7/2026', 10, 0, 'AM')).toBe(false)
+    })
+
+    it('checks time if session is today', () => {
+      expect(DateFormatUtils.isSessionInPast('6/7/2026', 11, 59, 'PM')).toBe(false)
+    })
+  })
+})

--- a/server/utils/dateFormatUtils.test.ts
+++ b/server/utils/dateFormatUtils.test.ts
@@ -151,4 +151,26 @@ describe('DateFormatUtils', () => {
       expect(DateFormatUtils.isSessionInPast('6/7/2026', 11, 59, 'PM')).toBe(false)
     })
   })
+
+  describe('isSessionEnded', () => {
+    it('returns true for sessions on past dates', () => {
+      expect(DateFormatUtils.isSessionEnded('5/7/2026', 10, 0, 'AM')).toBe(true)
+    })
+
+    it('returns false for sessions on future dates', () => {
+      expect(DateFormatUtils.isSessionEnded('7/7/2026', 10, 0, 'AM')).toBe(false)
+    })
+
+    it('returns true for sessions today when end time is before now', () => {
+      expect(DateFormatUtils.isSessionEnded('6/7/2026', 11, 59, 'AM')).toBe(true)
+    })
+
+    it('returns false for sessions today when end time is after now', () => {
+      expect(DateFormatUtils.isSessionEnded('6/7/2026', 12, 1, 'PM')).toBe(false)
+    })
+
+    it('returns false for sessions today when end time is exactly now', () => {
+      expect(DateFormatUtils.isSessionEnded('6/7/2026', 12, 0, 'PM')).toBe(false)
+    })
+  })
 })

--- a/server/utils/dateFormatUtils.ts
+++ b/server/utils/dateFormatUtils.ts
@@ -1,0 +1,192 @@
+/**
+ * Utilities for parsing and comparing dates in various formats (UK DD/MM/YYYY and ISO YYYY-MM-DD)
+ */
+export default class DateFormatUtils {
+  private static readonly isoDatePrefixPattern = /^\d{4}-\d{2}-\d{2}$/
+
+  private static readonly ukDatePattern = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/
+
+  private static extractISODatePrefix(dateStr: string): string | null {
+    const isoDatePrefix = dateStr.slice(0, 10)
+    return DateFormatUtils.isoDatePrefixPattern.test(isoDatePrefix) ? isoDatePrefix : null
+  }
+
+  /**
+   * Parses a UK format date string (DD/MM/YYYY) to a Date object
+   * Sets time to midnight (00:00:00)
+   */
+  static parseUKDateToDate(dateStr: string): Date | null {
+    if (typeof dateStr !== 'string') {
+      return null
+    }
+
+    const ukMatch = dateStr.match(DateFormatUtils.ukDatePattern)
+    if (!ukMatch) {
+      return null
+    }
+
+    const [, day, month, year] = ukMatch
+    const date = new Date(Number(year), Number(month) - 1, Number(day))
+    date.setHours(0, 0, 0, 0)
+    return date
+  }
+
+  /**
+   * Parses an ISO format date string (YYYY-MM-DD) to a Date object
+   * Sets time to midnight (00:00:00)
+   */
+  static parseISODateToDate(dateStr: string): Date | null {
+    if (typeof dateStr !== 'string') {
+      return null
+    }
+
+    const isoDatePrefix = DateFormatUtils.extractISODatePrefix(dateStr)
+    if (!isoDatePrefix) {
+      return null
+    }
+
+    const [year, month, day] = isoDatePrefix.split('-')
+    const date = new Date(Number(year), Number(month) - 1, Number(day))
+    date.setHours(0, 0, 0, 0)
+    return date
+  }
+
+  /**
+   * Attempts to parse a date string in either UK or ISO format
+   * Returns null if format cannot be determined
+   */
+  static parseDate(dateStr: string): Date | null {
+    let date = DateFormatUtils.parseISODateToDate(dateStr)
+    if (date) return date
+
+    date = DateFormatUtils.parseUKDateToDate(dateStr)
+    if (date) return date
+
+    return null
+  }
+
+  /**
+   * Converts a date string (UK or ISO format) to YYYY-MM-DD format
+   * Returns null if date cannot be parsed
+   */
+  static toDateOnlyISO(dateStr: string): string | null {
+    if (!dateStr) return null
+
+    const isoDatePrefix = DateFormatUtils.extractISODatePrefix(dateStr)
+    if (isoDatePrefix) {
+      return isoDatePrefix
+    }
+
+    const ukMatch = dateStr.match(DateFormatUtils.ukDatePattern)
+    if (ukMatch) {
+      const [, day, month, year] = ukMatch
+      return `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`
+    }
+
+    return null
+  }
+
+  /**
+   * Checks if a date (UK or ISO format) is in the past (before today at midnight)
+   */
+  static isDateInPast(dateStr: string): boolean {
+    const date = DateFormatUtils.parseDate(dateStr)
+    if (!date) return false
+
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+
+    return date < today
+  }
+
+  /**
+   * Checks if a date is today
+   */
+  static isDateToday(dateStr: string): boolean {
+    const date = DateFormatUtils.parseDate(dateStr)
+    if (!date) return false
+
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+
+    return date.getTime() === today.getTime()
+  }
+
+  /**
+   * Checks if a time on a given date (in UK format) has already passed
+   * Date should be today; returns false if date is not today
+   */
+  static hasTimePassedOnDate(dateStr: string, hour: number, minute: number, amOrPm: 'AM' | 'PM'): boolean {
+    if (!DateFormatUtils.isDateToday(dateStr)) {
+      return false
+    }
+
+    const date = DateFormatUtils.parseDate(dateStr)
+    if (!date) return false
+
+    // Convert 12-hour format to 24-hour
+    let hour24 = hour
+    if (amOrPm === 'AM') {
+      hour24 = hour === 12 ? 0 : hour
+    } else {
+      hour24 = hour === 12 ? 12 : hour + 12
+    }
+
+    const timeOnDate = new Date(date)
+    timeOnDate.setHours(hour24, minute, 0, 0)
+
+    const now = new Date()
+    return timeOnDate < now
+  }
+
+  /**
+   * Checks if a session (with date and start time) is in the past
+   * Accounts for both past dates and today's date if time has passed
+   */
+  static isSessionInPast(dateStr: string, hour: number, minute: number, amOrPm: 'AM' | 'PM'): boolean {
+    const date = DateFormatUtils.parseDate(dateStr)
+    if (!date) return false
+
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+
+    // If date is before today, session is in the past
+    if (date < today) {
+      return true
+    }
+
+    // If date is in the future, session is not in the past
+    if (date > today) {
+      return false
+    }
+
+    // Date is today - check if start time has passed
+    return DateFormatUtils.hasTimePassedOnDate(dateStr, hour, minute, amOrPm)
+  }
+
+  /**
+   * Checks if a session (with date and end time) has ended
+   * Returns true if the end time has already passed
+   * Used to prevent modifications to completed sessions
+   */
+  static isSessionEnded(dateStr: string, hour: number, minute: number, amOrPm: 'AM' | 'PM'): boolean {
+    const date = DateFormatUtils.parseDate(dateStr)
+    if (!date) return false
+
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+
+    // If date is before today, session has already ended
+    if (date < today) {
+      return true
+    }
+
+    // If date is in the future, session has not ended
+    if (date > today) {
+      return false
+    }
+
+    // Date is today - check if end time has passed
+    return DateFormatUtils.hasTimePassedOnDate(dateStr, hour, minute, amOrPm)
+  }
+}

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -218,4 +218,28 @@ describe('DateUtils', () => {
       expect(DateUtils.formatDateToDDMMYYYY('15-03-2021')).toEqual('15-03-2021')
     })
   })
+
+  describe('durationInMinutes', () => {
+    it('calculates duration for AM to PM range', () => {
+      expect(DateUtils.durationInMinutes(11, 30, 'AM', 1, 0, 'PM')).toBe(90)
+    })
+
+    it('handles same-period time ranges', () => {
+      expect(DateUtils.durationInMinutes(9, 15, 'AM', 10, 0, 'AM')).toBe(45)
+    })
+  })
+
+  describe('isTimeBefore', () => {
+    it('returns true when start is before end', () => {
+      expect(DateUtils.isTimeBefore(10, 0, 'AM', 10, 1, 'AM')).toBe(true)
+    })
+
+    it('returns false when start equals end', () => {
+      expect(DateUtils.isTimeBefore(10, 0, 'AM', 10, 0, 'AM')).toBe(false)
+    })
+
+    it('returns false when start is after end', () => {
+      expect(DateUtils.isTimeBefore(1, 0, 'PM', 12, 30, 'PM')).toBe(false)
+    })
+  })
 })

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -152,6 +152,36 @@ export default class DateUtils {
     return { hour: hour24, minute }
   }
 
+  static durationInMinutes(
+    startHour: number,
+    startMinute: number,
+    startPeriod: 'AM' | 'PM',
+    endHour: number,
+    endMinute: number,
+    endPeriod: 'AM' | 'PM',
+  ): number {
+    const start = DateUtils.convertTo24Hour(startHour, startMinute, startPeriod)
+    const end = DateUtils.convertTo24Hour(endHour, endMinute, endPeriod)
+    return end.hour * 60 + end.minute - (start.hour * 60 + start.minute)
+  }
+
+  static isTimeBefore(
+    startHour: number,
+    startMinute: number,
+    startPeriod: 'AM' | 'PM',
+    endHour: number,
+    endMinute: number,
+    endPeriod: 'AM' | 'PM',
+  ): boolean {
+    const start = DateUtils.convertTo24Hour(startHour, startMinute, startPeriod)
+    const end = DateUtils.convertTo24Hour(endHour, endMinute, endPeriod)
+
+    if (start.hour !== end.hour) {
+      return start.hour < end.hour
+    }
+    return start.minute < end.minute
+  }
+
   /**
    * Converts a date string to DD/MM/YYYY format
    * Handles both YYYY-MM-DD (API format) and DD/MM/YYYY (form format)

--- a/server/utils/errorMessages.ts
+++ b/server/utils/errorMessages.ts
@@ -108,6 +108,8 @@ export default {
     sessionDetailsWho: 'Select who should attend the session',
     sessionDetailsFacilitator: 'Select a facilitator. Start typing to search',
     sessionDetailsEndTimeBeforeStart: 'End time must be later than start time',
+    sessionDetailsDurationLongerThanOriginallyScheduled:
+      'The session duration cannot be longer than originally scheduled. Change the start or end time.',
   },
   rescheduleSession: {
     editSessionDateAndTime: {
@@ -122,6 +124,8 @@ export default {
       sessionDetailsEndTimeAmPm: 'Select whether the end time is am or pm',
       sessionDetailsFacilitator: 'Select a facilitator. Start typing to search',
       sessionDetailsEndTimeBeforeStart: 'End time must be later than start time',
+      sessionDetailsDurationLongerThanOriginallyScheduled:
+        'The session duration cannot be longer than originally scheduled. Change the start or end time.',
     },
     rescheduleOtherSessions: {
       rescheduleOtherSessionsEmpty: 'Select whether to reschedule future sessions or not',

--- a/server/utils/presenterUtils.test.ts
+++ b/server/utils/presenterUtils.test.ts
@@ -525,8 +525,8 @@ describe(PresenterUtils, () => {
             'Please enter an hour and select whether the time is in the AM or the PM',
           ])
           expect(value.hour.hasError).toEqual(true)
-          expect(value.minute.hasError).toEqual(false)
-          expect(value.partOfDay.hasError).toEqual(false)
+          expect(value.minute.hasError).toEqual(true)
+          expect(value.partOfDay.hasError).toEqual(true)
         })
 
         it('returns multiple error information', () => {
@@ -551,7 +551,7 @@ describe(PresenterUtils, () => {
             'Please enter an hour and select whether the time is in the AM or the PM',
           ])
           expect(value.hour.hasError).toEqual(true)
-          expect(value.minute.hasError).toEqual(false)
+          expect(value.minute.hasError).toEqual(true)
           expect(value.partOfDay.hasError).toEqual(true)
         })
       })

--- a/server/utils/presenterUtils.ts
+++ b/server/utils/presenterUtils.ts
@@ -143,20 +143,25 @@ export default class PresenterUtils {
       minuteValue = modelValue.minutes !== undefined ? modelValue.minutes.toString().padStart(2, '0') : ''
       partOfDayValue = modelValue.amOrPm ?? null
     }
+    // If any of the three fields has an error, highlight all three
+    const groupHasError =
+      PresenterUtils.hasError(error, hourKey) ||
+      PresenterUtils.hasError(error, minuteKey) ||
+      PresenterUtils.hasError(error, partOfDayKey)
 
     return {
       errorMessages,
       partOfDay: {
         value: partOfDayValue,
-        hasError: PresenterUtils.hasError(error, partOfDayKey),
+        hasError: groupHasError,
       },
       hour: {
         value: hourValue,
-        hasError: PresenterUtils.hasError(error, hourKey),
+        hasError: groupHasError,
       },
       minute: {
         value: minuteValue,
-        hasError: PresenterUtils.hasError(error, minuteKey),
+        hasError: groupHasError,
       },
     }
   }


### PR DESCRIPTION
Session where the end date and time are in the past should be able to have the time changed but only if the session is not made any longer.

Help from Claude esp. on the DateUtils.

Error message showing

<img width="1393" height="1032" alt="Screenshot 2026-06-04 at 14 19 53" src="https://github.com/user-attachments/assets/7161a3a3-6817-4d7a-b774-cf0594b5b574" />
