### PR TITLE
Re-order headings for accessibility

### DIFF
--- a/server/createGroup/region/createOrEditGroupPduView.ts
+++ b/server/createGroup/region/createOrEditGroupPduView.ts
@@ -17,13 +17,9 @@ export default class CreateOrEditGroupPduView {
       id: 'create-group-pdu',
       name: 'create-group-pdu',
       label: {
-        text: this.presenter.text.headingText,
-        classes: 'govuk-label--l',
-        isPageHeading: true,
-      },
-      hint: {
         text: 'Search for PDU',
-        classes: 'govuk-label--m govuk-label govuk-!-margin-top-6',
+        classes: 'govuk-label--m',
+        isPageHeading: false,
       },
       errorMessage: ViewUtils.govukErrorMessage(this.presenter.fields.createGroupPdu.errorMessage),
       items: this.presenter.generateSelectOptions(),

--- a/server/views/createGroup/createGroupPdu.njk
+++ b/server/views/createGroup/createGroupPdu.njk
@@ -24,6 +24,7 @@
         <span class="govuk-caption-l">{{ text.headingHintText }}</span>
         <form method="post" novalidate>
           <input type="hidden" name="_csrf" value="{{csrfToken}}">
+          <h1 class="govuk-heading-l">{{ text.headingText }}</h1>
           {{ govukSelect(createGroupPduArgs) }}
           <script src="/assets/accessible-autocomplete.min.js"></script>
           <script nonce="{{ cspNonce }}">


### PR DESCRIPTION
Re-order headings for accessibility
<img width="1325" height="642" alt="Screenshot 2026-06-09 at 13 31 36" src="https://github.com/user-attachments/assets/85b0373f-2af1-4a61-b6eb-31f1b88a1b38" />
