### PR TITLE
Move edit session success messages 

### DIFF
--- a/server/editSession/editSessionController.test.ts
+++ b/server/editSession/editSessionController.test.ts
@@ -214,7 +214,7 @@ describe('editSessionDateAndTime', () => {
           'session-details-end-time-part-of-day': 'AM',
         })
         .expect(302)
-        .expect('Location', '/111/6789/edit-session?message=Test%20message')
+        .expect('Location', '/111/6789/edit-session?editSessionMessage=Test%20message')
 
       expect(accreditedProgrammesManageAndDeliverService.updateSessionDateAndTime).toHaveBeenCalledWith(
         'user1',
@@ -396,7 +396,7 @@ describe('submitEditSessionDateAndTime', () => {
         .expect(302)
         .expect(res => {
           expect(res.text).toContain(
-            `Redirecting to /111/6789/edit-session?message=${encodeURIComponent('Test message')}`,
+            `Redirecting to /111/6789/edit-session?editSessionMessage=${encodeURIComponent('Test message')}`,
           )
         })
     })
@@ -482,7 +482,7 @@ describe('editSessionFacilitators', () => {
         .expect(302)
         .expect(res => {
           expect(res.text).toContain(
-            `Found. Redirecting to /${groupId}/${sessionId}/edit-session?message=${encodeURIComponent('Facilitators updated successfully')}`,
+            `Found. Redirecting to /${groupId}/${sessionId}/edit-session?editSessionMessage=${encodeURIComponent('Facilitators updated successfully')}`,
           )
         })
     })

--- a/server/editSession/editSessionController.ts
+++ b/server/editSession/editSessionController.ts
@@ -149,7 +149,7 @@ export default class EditSessionController extends BaseController {
   async editSession(req: Request, res: Response): Promise<void> {
     const { groupId, sessionId } = req.params as Record<string, string>
     const { username } = req.user
-    const { message, isAttendanceHistory, referralId } = req.query
+    const { message, isAttendanceHistory, referralId, editSessionMessage } = req.query
     let formError: FormValidationError | null = null
 
     req.session.editSessionDateAndTime = {}
@@ -161,6 +161,7 @@ export default class EditSessionController extends BaseController {
     )
 
     const successMessage = message ? String(message) : null
+    const editSessionSuccessMessage = editSessionMessage ? String(editSessionMessage) : null
     const isAttendanceHistoryFlag = isAttendanceHistory === 'true'
     const attendanceHistoryReferralId = referralId ? String(referralId) : null
     const moduleName = convertToUrlFriendlyKebabCase(
@@ -190,6 +191,7 @@ export default class EditSessionController extends BaseController {
       sessionId,
       `/${groupId}/${sessionId}/delete-session`,
       successMessage,
+      editSessionSuccessMessage,
       isAttendanceHistoryFlag,
       formError,
       attendanceHistoryReferralId,
@@ -212,7 +214,7 @@ export default class EditSessionController extends BaseController {
         formError = data.error
       } else if (data.paramsForUpdate?.delete === 'yes') {
         const response = await this.accreditedProgrammesManageAndDeliverService.deleteSession(username, sessionId)
-        return res.redirect(`/group/${groupId}/sessions-and-attendance?successMessage=${response}`)
+        return res.redirect(`/group/${groupId}/sessions-and-attendance?editSessionMessage=${response}`)
       } else {
         return res.redirect(req.session.originPage)
       }
@@ -243,7 +245,7 @@ export default class EditSessionController extends BaseController {
           sessionId,
           data.paramsForUpdate.referralId,
         )
-        return res.redirect(`/${groupId}/${sessionId}/edit-session?message=${message}`)
+        return res.redirect(`/${groupId}/${sessionId}/edit-session?editSessionMessage=${message}`)
       }
     }
 
@@ -363,7 +365,7 @@ export default class EditSessionController extends BaseController {
 
         delete req.session.editSessionDateAndTime
 
-        return res.redirect(`/${groupId}/${sessionId}/edit-session?message=${response.message}`)
+        return res.redirect(`/${groupId}/${sessionId}/edit-session?editSessionMessage=${response.message}`)
       }
     }
     const presenter = new EditSessionDateAndTimePresenter(
@@ -406,7 +408,7 @@ export default class EditSessionController extends BaseController {
           req.session.editSessionDateAndTime as RescheduleSessionRequest,
         )
 
-        return res.redirect(`/${groupId}/${sessionId}/edit-session?message=${message.message}`)
+        return res.redirect(`/${groupId}/${sessionId}/edit-session?editSessionMessage=${message.message}`)
       }
     }
 
@@ -440,7 +442,7 @@ export default class EditSessionController extends BaseController {
           sessionId,
           req.session.sessionFacilitators,
         )
-        return res.redirect(`/${groupId}/${sessionId}/edit-session?message=${message}`)
+        return res.redirect(`/${groupId}/${sessionId}/edit-session?editSessionMessage=${message}`)
       }
     }
     const presenter = new EditSessionFacilitatorsPresenter(

--- a/server/editSession/editSessionPresenter.test.ts
+++ b/server/editSession/editSessionPresenter.test.ts
@@ -496,6 +496,7 @@ describe('EditSessionPresenter', () => {
           mockSessionId,
           mockDeleteUrl,
           null,
+          null,
           true,
           null,
           'abc123',
@@ -515,6 +516,7 @@ describe('EditSessionPresenter', () => {
           sessionDetails,
           mockSessionId,
           mockDeleteUrl,
+          null,
           null,
           false,
         )

--- a/server/editSession/editSessionPresenter.ts
+++ b/server/editSession/editSessionPresenter.ts
@@ -14,6 +14,7 @@ export default class EditSessionPresenter {
     readonly sessionId: string,
     readonly deleteUrl: string,
     readonly successMessage: string | null = null,
+    readonly editSessionSuccessMessage: string | null = null,
     readonly isAttendanceHistory: boolean = false,
     private readonly validationError: FormValidationError | null = null,
     private readonly attendanceHistoryReferralId: string | null = null,

--- a/server/editSession/editSessionView.ts
+++ b/server/editSession/editSessionView.ts
@@ -108,6 +108,19 @@ export default class EditSessionView {
     }
   }
 
+  private get successEditSessionMessageArgs() {
+    if (!this.presenter.editSessionSuccessMessage) {
+      return null
+    }
+
+    return {
+      variant: 'success',
+      title: this.presenter.editSessionSuccessMessage,
+      showTitleAsHeading: true,
+      dismissible: true,
+    }
+  }
+
   get deleteButton(): ButtonArgs {
     return {
       text: 'Delete session',
@@ -142,6 +155,7 @@ export default class EditSessionView {
         backLinkArgs: this.presenter.backLinkArgs,
         editSessionSummary: this.editSessionSummary,
         successMessageArgs: this.successMessageArgs,
+        successEditSessionMessageArgs: this.successEditSessionMessageArgs,
         deleteButton: this.deleteButton,
         canBeDeleted: this.presenter.canBeDeleted,
         attendanceTableArgs: this.presenter.attendanceTableArgs,

--- a/server/views/editSession/editSession.njk
+++ b/server/views/editSession/editSession.njk
@@ -15,8 +15,12 @@
       <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-2">
         {{ govukBackLink(backLinkArgs) }}
       </div>
-
       <div class="govuk-grid-column-two-thirds">
+
+        {% if successEditSessionMessageArgs !== null %}
+        {{ mojAlert(successEditSessionMessageArgs) }}
+        {% endif %}
+        
         <span class="govuk-caption-l">{{text.pageCaption}}</span>
         <h1 class="govuk-heading-l">{{text.pageHeading}}</h1>
       </div>


### PR DESCRIPTION
Move edit session success messages while keeping notes and attendance success messages where they already are

<img width="1259" height="953" alt="Screenshot 2026-06-10 at 10 41 57" src="https://github.com/user-attachments/assets/55de522d-ea13-4e53-a0c7-684cd01c5130" />

<img width="898" height="952" alt="Screenshot 2026-06-10 at 10 43 51" src="https://github.com/user-attachments/assets/90b2f2f6-de71-4690-9af0-5fa7488a2e2c" />
