### PR TITLE
Enable ModSecurity and configure GitHub team for UI deployment

### DIFF
--- a/helm_deploy/hmpps-accredited-programmes-manage-and-deliver-ui/values.yaml
+++ b/helm_deploy/hmpps-accredited-programmes-manage-and-deliver-ui/values.yaml
@@ -16,7 +16,8 @@ generic-service:
     enabled: true
     host: app-hostname.local # override per environment
     tlsSecretName: hmpps-manage-and-deliver-accredited-programmes-ui-cert
-
+    modsecurity_enabled: true
+    modsecurity_github_team: hmpps-accredited-programmes-manage-and-deliver-devs
 
   livenessProbe:
     httpGet:


### PR DESCRIPTION
This pull request enables ModSecurity for enhanced application security and configures the appropriate GitHub team for accredited programmes UI deployment.