### PR TITLE
Correcting cancel link

### DIFF
--- a/server/groupOverview/removeFromGroup/removeFromGroupPresenter.test.ts
+++ b/server/groupOverview/removeFromGroup/removeFromGroupPresenter.test.ts
@@ -25,6 +25,6 @@ describe('RemoveFromGroupPresenter', () => {
 
   it('should return correct cancelLinkHref', () => {
     const presenter = new RemoveFromGroupPresenter(groupId, groupManagementData, backLink)
-    expect(presenter.cancelLinkHref).toBe('/group/group-1/waitlist')
+    expect(presenter.cancelLinkHref).toBe('/group/group-1/allocations')
   })
 })

--- a/server/groupOverview/removeFromGroup/removeFromGroupPresenter.ts
+++ b/server/groupOverview/removeFromGroup/removeFromGroupPresenter.ts
@@ -29,7 +29,7 @@ export default class RemoveFromGroupPresenter {
   }
 
   get cancelLinkHref() {
-    return `/group/${this.groupId}/waitlist`
+    return `/group/${this.groupId}/allocations`
   }
 
   get utils() {

--- a/server/groupOverview/removeFromGroup/removeFromGroupUpdateStatusPresenter.test.ts
+++ b/server/groupOverview/removeFromGroup/removeFromGroupUpdateStatusPresenter.test.ts
@@ -21,7 +21,7 @@ describe('RemoveFromGroupUpdateStatusPresenter', () => {
 
   it('should return correct cancelLinkHref', () => {
     const presenter = new RemoveFromGroupUpdateStatusPresenter(groupId, statusDetails, backLinkUri, groupManagementData)
-    expect(presenter.cancelLinkHref).toBe('/group/group-1/waitlist')
+    expect(presenter.cancelLinkHref).toBe('/group/group-1/allocations')
   })
 
   it('should return null errorSummary when no validation error', () => {

--- a/server/groupOverview/removeFromGroup/removeFromGroupUpdateStatusPresenter.ts
+++ b/server/groupOverview/removeFromGroup/removeFromGroupUpdateStatusPresenter.ts
@@ -27,7 +27,7 @@ export default class RemoveFromGroupUpdateStatusPresenter {
   }
 
   get cancelLinkHref() {
-    return `/group/${this.groupId}/waitlist`
+    return `/group/${this.groupId}/allocations`
   }
 
   get utils() {


### PR DESCRIPTION
When removing someone from a group the cancel button should return them to the allocated list for that group