### PR TITLE
Adding in coloured status tags on the caselist page

### DIFF
--- a/server/@types/manageAndDeliverApi/imported/index.d.ts
+++ b/server/@types/manageAndDeliverApi/imported/index.d.ts
@@ -3260,10 +3260,10 @@ export interface components {
       content?: components['schemas']['ReferralCaseListItem'][]
       /** Format: int32 */
       number?: number
-      first?: boolean
-      last?: boolean
       sort?: components['schemas']['SortObject']
       pageable?: components['schemas']['PageableObject']
+      first?: boolean
+      last?: boolean
       /** Format: int32 */
       numberOfElements?: number
       empty?: boolean
@@ -3271,13 +3271,13 @@ export interface components {
     PageableObject: {
       /** Format: int64 */
       offset?: number
+      unpaged?: boolean
       sort?: components['schemas']['SortObject']
-      /** Format: int32 */
-      pageSize?: number
       /** Format: int32 */
       pageNumber?: number
       paged?: boolean
-      unpaged?: boolean
+      /** Format: int32 */
+      pageSize?: number
     }
     ReferralCaseListItem: {
       /** Format: uuid */
@@ -3285,6 +3285,7 @@ export interface components {
       crn: string
       personName: string
       referralStatus: string
+      statusLabelColour: string
       /**
        * @description Offence classification based on assessment
        * @enum {string}
@@ -3300,8 +3301,8 @@ export interface components {
     }
     SortObject: {
       empty?: boolean
-      sorted?: boolean
       unsorted?: boolean
+      sorted?: boolean
     }
     StatusFilterValues: {
       /**
@@ -3933,10 +3934,10 @@ export interface components {
       content?: components['schemas']['Group'][]
       /** Format: int32 */
       number?: number
-      first?: boolean
-      last?: boolean
       sort?: components['schemas']['SortObject']
       pageable?: components['schemas']['PageableObject']
+      first?: boolean
+      last?: boolean
       /** Format: int32 */
       numberOfElements?: number
       empty?: boolean
@@ -4028,10 +4029,10 @@ export interface components {
       content?: components['schemas']['GroupItem'][]
       /** Format: int32 */
       number?: number
-      first?: boolean
-      last?: boolean
       sort?: components['schemas']['SortObject']
       pageable?: components['schemas']['PageableObject']
+      first?: boolean
+      last?: boolean
       /** Format: int32 */
       numberOfElements?: number
       empty?: boolean

--- a/server/caselist/caselistPresenter.test.ts
+++ b/server/caselist/caselistPresenter.test.ts
@@ -353,6 +353,7 @@ describe('generateTableRows', () => {
       cohort: 'GENERAL_OFFENCE',
       hasLdc: false,
       referralStatus: 'Awaiting allocation',
+      statusLabelColour: 'teal',
     })
     const referralCaseListItemPage: Page<ReferralCaseListItem> = pageFactory
       .pageContent([referralCaseListItem])
@@ -384,7 +385,9 @@ describe('generateTableRows', () => {
       attributes: { 'data-sort-value': sentenceEndDateTimestamp },
     })
     expect(rows[0][4]).toEqual({ html: 'General offence' })
-    expect(rows[0][5]).toEqual({ text: 'Awaiting allocation' })
+    expect(rows[0][5]).toEqual({
+      html: `<strong class="govuk-tag govuk-tag--teal">Awaiting allocation</strong>`,
+    })
   })
 
   it('should generate correct sentence end date with LICENCE_CONDITION source', () => {

--- a/server/caselist/caselistPresenter.ts
+++ b/server/caselist/caselistPresenter.ts
@@ -153,7 +153,9 @@ export default class CaselistPresenter {
         {
           html: `${cohortConfigMap[referral.cohort]}${CaselistUtils.hasLdcTagHtml(referral)}`,
         },
-        { text: referral.referralStatus },
+        {
+          html: `<strong class="govuk-tag govuk-tag--${referral.statusLabelColour}">${referral.referralStatus}</strong>`,
+        },
       ])
     })
     return referralData

--- a/server/testutils/factories/referralCaseListItem.ts
+++ b/server/testutils/factories/referralCaseListItem.ts
@@ -14,4 +14,5 @@ export default ReferralCaseListItemFactory.define(({ sequence }) => ({
   pdu: 'PDU_NAME_1',
   sentenceEndDate: '2024-01-01',
   sentenceEndDateSource: 'LICENCE_CONDITION' as 'LICENCE_CONDITION' | 'REQUIREMENT',
+  statusLabelColour: 'blue',
 }))


### PR DESCRIPTION
Adding in coloured status tags on the caselist page
Open
<img width="3456" height="4786" alt="image" src="https://github.com/user-attachments/assets/76394159-47ee-4782-a942-e89311af8527" />
Closed
<img width="3456" height="2303" alt="image" src="https://github.com/user-attachments/assets/2079eea6-d6b8-4c5b-9320-1506e2f08459" />

