### PR TITLE
Correcting font for the autocomplete hint to stop overlapping text

### DIFF
--- a/assets/scss/components/_accessible_autocomplete.scss
+++ b/assets/scss/components/_accessible_autocomplete.scss
@@ -6,3 +6,6 @@
   font-family: GDS Transport, arial, sans-serif
 }
 
+.autocomplete__hint {
+  font-family: GDS Transport, arial, sans-serif
+}


### PR DESCRIPTION
Correcting the hint text font to prevent a weird overlap when typing
Before
<img width="935" height="391" alt="Screenshot 2026-06-15 at 14 46 06" src="https://github.com/user-attachments/assets/19e92453-99e5-4641-ba92-584fc7c75701" />
After
<img width="954" height="379" alt="Screenshot 2026-06-15 at 14 49 50" src="https://github.com/user-attachments/assets/f6eeecf4-9233-4f4e-a518-213a9d42fae8" />
