### PR TITLE
amending the ALLOWED_PAST_DATE_REGIONS to N54

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -17,7 +17,7 @@ generic-service:
     ENVIRONMENT_NAME: DEV
     AUDIT_ENABLED: "false"
     SENTRY_ENVIRONMENT: dev
-    ENABLE_PAST_DATE_REGION_RESTRICTION: "false"
+    ENABLE_PAST_DATE_REGION_RESTRICTION: "true"
 
   allowlist:
     accessibility-audit-usr: 5.181.59.114

--- a/server/createGroup/allowedPastDateRegions.ts
+++ b/server/createGroup/allowedPastDateRegions.ts
@@ -1,4 +1,8 @@
-export const ALLOWED_PAST_DATE_REGIONS: string[] = ['N53']
+/** For info: N54 is the North East
+ * CreateGroupFormTest.test.ts also needs to be updated to reflect the change to the region
+ */
+
+export const ALLOWED_PAST_DATE_REGIONS: string[] = ['N54']
 
 /**
  * Checks if the region restriction for past dates is enabled.

--- a/server/createGroup/createGroupForm.test.ts
+++ b/server/createGroup/createGroupForm.test.ts
@@ -176,12 +176,12 @@ describe('CreateGroupForm', () => {
           expect(data.error.errors[0].message).toBe('Start date must be in the future')
         })
 
-        it('allows past dates for region in allowed list (N53)', async () => {
+        it('allows past dates for region in allowed list (N54)', async () => {
           const request = TestUtils.createRequest({
             'create-group-date': '1/1/2000',
           })
 
-          const data = await new CreateOrEditGroupForm(request, undefined, 'N53').createOrEditGroupDateData()
+          const data = await new CreateOrEditGroupForm(request, undefined, 'N54').createOrEditGroupDateData()
 
           expect(data.paramsForUpdate).toStrictEqual({
             earliestStartDate: '1/1/2000',

--- a/wiremock_mappings/delius.json
+++ b/wiremock_mappings/delius.json
@@ -516,8 +516,8 @@
                 "description": "Wiremocked PDU"
               },
               "region": {
-                "code": "wiremocked_region_code",
-                "description": "Wiremocked Region Name"
+                "code": "N54",
+                "description": "Wiremocked N54 Region"
               }
             }
           ]


### PR DESCRIPTION
We want the North East (N54) to be the only group able to create groups in the past. Previously this was restricted to the the East Midlands (N53). 