### PR TITLE
APG-1956: duplication removed on status history

### DIFF
--- a/server/referralDetails/statusHistoryView.ts
+++ b/server/referralDetails/statusHistoryView.ts
@@ -22,19 +22,13 @@ export default class StatusHistoryView {
     return {
       items: this.presenter.statusHistory.toReversed().map((status: ReferralStatusHistory) => ({
         label: {
-          text: status.referralStatusDescriptionName,
+          text: `Status update by ${status.updatedBy}`,
         },
         html: makeStatusTagHtml(status.tagColour, status.referralStatusDescriptionName, status.additionalDetails),
         datetime: {
           timestamp: DateUtils.removeTimezoneOffset(status.updatedAt),
           type: 'datetime',
         },
-        byline: {
-          text: status.updatedBy,
-        },
-        ...(status.additionalDetails && {
-          html: makeStatusTagHtml(status.tagColour, status.referralStatusDescriptionName, status.additionalDetails),
-        }),
       })),
     }
   }


### PR DESCRIPTION
Figma example\:| https://www.figma.com/design/Y1h09XHyEI9O8KZoOpvlTS/Accredited-Programmes--Community-?node-id=12903-64684&t=2uoSP8pYG3OnuLID-1


'Status update' text added to each line instead of the status which is currently showing

After:

<img width="1130" height="1028" alt="Screenshot 2026-06-24 at 14 21 01" src="https://github.com/user-attachments/assets/f424fed0-952a-4537-a8ee-bd00c2420a62" />


Before:

<img width="1130" height="1028" alt="Screenshot 2026-06-24 at 14 22 06" src="https://github.com/user-attachments/assets/fedc6526-c614-4e33-a349-72472d9e8fe2" />
