### PR TITLE
Text updates in Review your group details from design review

### DIFF
--- a/server/createGroup/check-your-answers/createGroupCyaPresenter.test.ts
+++ b/server/createGroup/check-your-answers/createGroupCyaPresenter.test.ts
@@ -217,14 +217,19 @@ describe('CreateGroupCyaPresenter', () => {
       const summary = presenter.getCreateGroupSummary()
 
       expect(summary).toContainEqual({
-        key: 'Group Code',
+        key: 'Group code',
         lines: ['ABC123'],
         changeLink: '/create-group-code',
       })
       expect(summary).toContainEqual({
-        key: 'Date',
+        key: 'Start date',
         lines: ['2026-06-01'],
         changeLink: '/group-start-date',
+      })
+      expect(summary).toContainEqual({
+        key: 'Days and times',
+        lines: ['Monday 2:00 PM - 4:00 PM'],
+        changeLink: '/group-days-and-times',
       })
       expect(summary).toContainEqual({
         key: 'Cohort',
@@ -242,7 +247,7 @@ describe('CreateGroupCyaPresenter', () => {
         changeLink: '/group-probation-delivery-unit',
       })
       expect(summary).toContainEqual({
-        key: 'Delivery Location',
+        key: 'Delivery location',
         lines: ['Prison A'],
         changeLink: '/group-delivery-location',
       })
@@ -424,7 +429,7 @@ describe('CreateGroupCyaPresenter', () => {
       const summary = presenter.getCreateGroupSummary()
 
       expect(summary).toContainEqual({
-        key: 'Day and time',
+        key: 'Days and times',
         lines: ['Monday 2:00 PM - 4:00 PM', 'Wednesday 10:00 AM - 12:00 PM'],
         changeLink: '/group-days-and-times',
       })
@@ -469,13 +474,13 @@ describe('CreateGroupCyaPresenter', () => {
       const summary = presenter.getCreateGroupSummary()
 
       expect(summary.length).toBe(10) // All 10 items including cover facilitators
-      expect(summary[0].key).toBe('Group Code')
-      expect(summary[1].key).toBe('Date')
-      expect(summary[2].key).toBe('Day and time')
+      expect(summary[0].key).toBe('Group code')
+      expect(summary[1].key).toBe('Start date')
+      expect(summary[2].key).toBe('Days and times')
       expect(summary[3].key).toBe('Cohort')
       expect(summary[4].key).toBe('Gender')
       expect(summary[5].key).toBe('PDU')
-      expect(summary[6].key).toBe('Delivery Location')
+      expect(summary[6].key).toBe('Delivery location')
       expect(summary[7].key).toBe('Treatment Manager:')
       expect(summary[8].key).toBe('Facilitators:')
       expect(summary[9].key).toBe('Cover facilitators:')

--- a/server/createGroup/check-your-answers/createGroupCyaPresenter.ts
+++ b/server/createGroup/check-your-answers/createGroupCyaPresenter.ts
@@ -50,18 +50,18 @@ export default class CreateGroupCyaPresenter {
     const members = this.generateSelectedUsers()
     const summaryList = [
       {
-        key: 'Group Code',
+        key: 'Group code',
         lines: [`${this.createGroupFormData.groupCode}`],
         changeLink: '/create-group-code',
       },
       {
-        key: 'Date',
+        key: 'Start date',
         lines: [`${this.createGroupFormData.earliestStartDate}`],
         changeLink: '/group-start-date',
       },
 
       {
-        key: 'Day and time',
+        key: 'Days and times',
         lines: GroupDaysTimesUtils.formatStartDaysAndTimes(this.createGroupFormData.createGroupSessionSlot),
         changeLink: '/group-days-and-times',
       },
@@ -82,7 +82,7 @@ export default class CreateGroupCyaPresenter {
         changeLink: '/group-probation-delivery-unit',
       },
       {
-        key: 'Delivery Location',
+        key: 'Delivery location',
         lines: [`${this.createGroupFormData.deliveryLocationName}`],
         changeLink: '/group-delivery-location',
       },


### PR DESCRIPTION
Some small sentence case and text issues.

'Group Code' to 'Group code'
'Date' to 'Start date'
'Day and time' to 'Days and times'
'Delivery Location' to 'Delivery location'


Before:

<img width="898" height="697" alt="Screenshot 2026-06-24 at 14 53 23" src="https://github.com/user-attachments/assets/d6d305a8-8df5-43be-9276-d4305fb7c5e3" />

After:


<img width="898" height="697" alt="Screenshot 2026-06-24 at 14 54 30" src="https://github.com/user-attachments/assets/0d5df667-9b9d-4cc4-9eac-2bbb9acfbe52" />
