### PR TITLE
text change for location the person can attend

### DIFF
--- a/server/availabilityAndMotivation/location/locationPresenter.test.ts
+++ b/server/availabilityAndMotivation/location/locationPresenter.test.ts
@@ -1,4 +1,4 @@
-import { DeliveryLocationPreferences, ReferralDetails } from '@manage-and-deliver-api'
+import { DeliveryLocationPreferences } from '@manage-and-deliver-api'
 import LocationPresenter from './locationPresenter'
 import referralDetailsFactory from '../../testutils/factories/referralDetailsFactory'
 

--- a/server/availabilityAndMotivation/location/locationPresenter.test.ts
+++ b/server/availabilityAndMotivation/location/locationPresenter.test.ts
@@ -1,0 +1,81 @@
+import { DeliveryLocationPreferences, ReferralDetails } from '@manage-and-deliver-api'
+import LocationPresenter from './locationPresenter'
+import referralDetailsFactory from '../../testutils/factories/referralDetailsFactory'
+
+describe('LocationPresenter', () => {
+  it('should return "Add location preferences" when no locations are set', () => {
+    const mockDeliveryLocationPreferences = {
+      preferredDeliveryLocations: [],
+      cannotAttendLocations: null,
+    } as DeliveryLocationPreferences
+
+    const mockDetails = referralDetailsFactory.build()
+    const presenter = new LocationPresenter(mockDetails, 'location', mockDeliveryLocationPreferences)
+
+    expect(presenter.linkText).toEqual('Add location preferences')
+  })
+
+  it('should return "Update location preferences" when preferred locations are set', () => {
+    const mockDeliveryLocationPreferences = {
+      preferredDeliveryLocations: ['Location 1', 'Location 2'],
+      cannotAttendLocations: null,
+    } as DeliveryLocationPreferences
+
+    const mockDetails = referralDetailsFactory.build()
+    const presenter = new LocationPresenter(mockDetails, 'location', mockDeliveryLocationPreferences)
+
+    expect(presenter.linkText).toEqual('Update location preferences')
+  })
+
+  it('should return "Update location preferences" when cannot attend locations are set', () => {
+    const mockDeliveryLocationPreferences = {
+      preferredDeliveryLocations: [],
+      cannotAttendLocations: 'Cannot attend prison locations',
+    } as DeliveryLocationPreferences
+
+    const mockDetails = referralDetailsFactory.build()
+    const presenter = new LocationPresenter(mockDetails, 'location', mockDeliveryLocationPreferences)
+
+    expect(presenter.linkText).toEqual('Update location preferences')
+  })
+
+  it('should return preferred locations summary with last updated info', () => {
+    const mockDeliveryLocationPreferences = {
+      preferredDeliveryLocations: ['Location A', 'Location B'],
+      cannotAttendLocations: 'Cannot attend Location C',
+      lastUpdatedAt: '2024-01-15',
+      lastUpdatedBy: 'John Smith',
+    } as DeliveryLocationPreferences
+
+    const mockDetails = referralDetailsFactory.build()
+    const presenter = new LocationPresenter(mockDetails, 'location', mockDeliveryLocationPreferences)
+
+    const summary = presenter.preferredLocationsSummary()
+
+    expect(summary.title).toEqual('Preferred programme delivery locations')
+    expect(summary.summary[0].lines).toContain('Last updated 2024-01-15 by John Smith')
+    expect(summary.summary[1].lines).toEqual(['Location A', 'Location B'])
+    expect(summary.summary[2].lines).toEqual(['Cannot attend Location C'])
+  })
+
+  it('should return locations summary with PDU and reporting team', () => {
+    const mockDeliveryLocationPreferences = {
+      preferredDeliveryLocations: [],
+      cannotAttendLocations: null,
+    } as DeliveryLocationPreferences
+
+    const mockDetails = referralDetailsFactory.build({
+      pdu: 'North PDU',
+      reportingTeam: 'Team A',
+    })
+    const presenter = new LocationPresenter(mockDetails, 'location', mockDeliveryLocationPreferences)
+
+    const summary = presenter.locationsSummary()
+
+    expect(summary.title).toEqual('Reporting locations')
+    expect(summary.summary[0].key).toEqual('Probation delivery unit')
+    expect(summary.summary[0].lines).toEqual(['North PDU'])
+    expect(summary.summary[1].key).toEqual('Reporting team')
+    expect(summary.summary[1].lines).toEqual(['Team A'])
+  })
+})

--- a/server/availabilityAndMotivation/location/locationPresenter.ts
+++ b/server/availabilityAndMotivation/location/locationPresenter.ts
@@ -27,7 +27,7 @@ export default class LocationPresenter extends AvailabilityAndMotivationPresente
 
     let summaryItems: SummaryListItem[] = [
       {
-        key: 'Preferred programme delivery locations',
+        key: 'Locations the person can attend',
         lines: preferredDeliveryLocations.length !== 0 ? preferredDeliveryLocations : ['No information added'],
       },
       {


### PR DESCRIPTION
Text update required from Design review.

Shown in Figma: https://www.figma.com/design/Y1h09XHyEI9O8KZoOpvlTS/Accredited-Programmes--Community-?node-id=12033-65661&t=2uoSP8pYG3OnuLID-1


Before:

<img width="898" height="697" alt="Screenshot 2026-06-24 at 15 27 35" src="https://github.com/user-attachments/assets/fd9a3764-dd12-4927-8150-3ffda283e3dc" />




After:
<img width="898" height="697" alt="Screenshot 2026-06-24 at 15 26 39" src="https://github.com/user-attachments/assets/31bb29d7-2859-4166-a868-8428fcfbda08" />
