### PR TITLE
APG-2407 css change to prevent the Accredited Programmes title disappearing at increased zoom

### DIFF
--- a/assets/scss/overrides/_local.scss
+++ b/assets/scss/overrides/_local.scss
@@ -160,3 +160,12 @@
   background: white;
   padding-top: 40px;
 }
+
+.hmpps-header__title {
+  padding-right: 10px;
+
+  &__service-name {
+    display: inline-block;
+  }
+}
+


### PR DESCRIPTION
Before:

<img width="1702" height="704" alt="Screenshot 2026-06-25 at 10 28 53" src="https://github.com/user-attachments/assets/49eb5129-3e18-4668-9c78-6ba2cd9e3fdb" />


After:

<img width="1702" height="704" alt="Screenshot 2026-06-25 at 10 28 34" src="https://github.com/user-attachments/assets/5173d065-5bc8-4261-a9e9-763d2c50e4db" />



