### PR TITLE
Empty table heading in allocations and waitlist

### DIFF
--- a/server/createGroup/check-your-answers/createGroupCyaPresenter.test.ts
+++ b/server/createGroup/check-your-answers/createGroupCyaPresenter.test.ts
@@ -259,13 +259,13 @@ describe('CreateGroupCyaPresenter', () => {
         visuallyHiddenText: 'delivery location',
       })
       expect(summary).toContainEqual({
-        key: 'Treatment Manager:',
+        key: 'Treatment Manager',
         lines: ['Not assigned'],
         changeLink: '/group-facilitators',
         visuallyHiddenText: 'treatment manager',
       })
       expect(summary).toContainEqual({
-        key: 'Facilitators:',
+        key: 'Facilitators',
         lines: ['None assigned'],
         changeLink: '/group-facilitators',
         visuallyHiddenText: 'facilitators',
@@ -295,7 +295,7 @@ describe('CreateGroupCyaPresenter', () => {
       const summary = presenter.getCreateGroupSummary()
 
       expect(summary).toContainEqual({
-        key: 'Treatment Manager:',
+        key: 'Treatment Manager',
         lines: ['John Smith'],
         changeLink: '/group-facilitators',
         visuallyHiddenText: 'treatment manager',
@@ -332,7 +332,7 @@ describe('CreateGroupCyaPresenter', () => {
       const summary = presenter.getCreateGroupSummary()
 
       expect(summary).toContainEqual({
-        key: 'Facilitators:',
+        key: 'Facilitators',
         lines: ['Jane Doe', 'Bob Johnson'],
         changeLink: '/group-facilitators',
         visuallyHiddenText: 'facilitators',
@@ -354,7 +354,7 @@ describe('CreateGroupCyaPresenter', () => {
 
       const summary = presenter.getCreateGroupSummary()
 
-      const coverFacilitatorItem = summary.find(item => item.key === 'Cover facilitators:')
+      const coverFacilitatorItem = summary.find(item => item.key === 'Cover facilitators')
       expect(coverFacilitatorItem).toBeUndefined()
     })
 
@@ -388,7 +388,7 @@ describe('CreateGroupCyaPresenter', () => {
       const summary = presenter.getCreateGroupSummary()
 
       expect(summary).toContainEqual({
-        key: 'Cover facilitators:',
+        key: 'Cover facilitators',
         lines: ['Alice Brown', 'Charlie Wilson'],
         changeLink: '/group-facilitators',
         visuallyHiddenText: 'cover facilitators',
@@ -494,9 +494,9 @@ describe('CreateGroupCyaPresenter', () => {
       expect(summary[4].key).toBe('Gender')
       expect(summary[5].key).toBe('PDU')
       expect(summary[6].key).toBe('Delivery location')
-      expect(summary[7].key).toBe('Treatment Manager:')
-      expect(summary[8].key).toBe('Facilitators:')
-      expect(summary[9].key).toBe('Cover facilitators:')
+      expect(summary[7].key).toBe('Treatment Manager')
+      expect(summary[8].key).toBe('Facilitators')
+      expect(summary[9].key).toBe('Cover facilitators')
     })
   })
 })

--- a/server/createGroup/check-your-answers/createGroupCyaPresenter.ts
+++ b/server/createGroup/check-your-answers/createGroupCyaPresenter.ts
@@ -94,13 +94,13 @@ export default class CreateGroupCyaPresenter {
         visuallyHiddenText: 'delivery location',
       },
       {
-        key: 'Treatment Manager:',
+        key: 'Treatment Manager',
         lines: [members.treatmentManager?.facilitator ?? 'Not assigned'],
         changeLink: '/group-facilitators',
         visuallyHiddenText: 'treatment manager',
       },
       {
-        key: 'Facilitators:',
+        key: 'Facilitators',
         lines:
           members.facilitators.length > 0 ? members.facilitators.map(member => member.facilitator) : ['None assigned'],
         changeLink: '/group-facilitators',
@@ -109,7 +109,7 @@ export default class CreateGroupCyaPresenter {
     ]
     if (members.coverFacilitators.length > 0) {
       summaryList.push({
-        key: 'Cover facilitators:',
+        key: 'Cover facilitators',
         lines:
           members.coverFacilitators.length > 0
             ? members.coverFacilitators.map(member => member.facilitator)

--- a/server/groupOverview/allocations/groupAllocationsPresenter.test.ts
+++ b/server/groupOverview/allocations/groupAllocationsPresenter.test.ts
@@ -46,7 +46,7 @@ describe('GroupAllocationsPresenter', () => {
         filterObject,
       )
       expect(presenter.generateTableHeadings()).toEqual([
-        { text: '' },
+        { text: 'Remove from group' },
         { text: 'Name and CRN', attributes: { 'aria-sort': 'ascending' } },
         { text: 'Sentence end date', attributes: { 'aria-sort': 'none' } },
         { text: 'Referral status', attributes: { 'aria-sort': 'none' } },
@@ -62,7 +62,7 @@ describe('GroupAllocationsPresenter', () => {
         filterObject,
       )
       expect(presenter.generateTableHeadings()).toEqual([
-        { text: '' },
+        { text: 'Add to group' },
         { text: 'Name and CRN', attributes: { 'aria-sort': 'ascending' } },
         { text: 'Sentence end date', attributes: { 'aria-sort': 'none' } },
         { text: 'Cohort', attributes: { 'aria-sort': 'none' } },

--- a/server/groupOverview/allocations/groupAllocationsPresenter.ts
+++ b/server/groupOverview/allocations/groupAllocationsPresenter.ts
@@ -110,7 +110,7 @@ export default class GroupAllocationsPresenter extends GroupServiceLayoutPresent
 
   generateTableHeadings(): TableArgsHeadElement[] {
     const baseHeadings: TableArgsHeadElement[] = [
-      { text: '' },
+      { text: this.section === GroupAllocationsPageSection.Allocated ? 'Remove from group' : 'Add to group' },
       { text: 'Name and CRN', attributes: { 'aria-sort': 'ascending' } },
       { text: 'Sentence end date', attributes: { 'aria-sort': 'none' } },
     ]


### PR DESCRIPTION
Table headings 'Add to group' and 'Remove from group' added.


<img width="1203" height="601" alt="Screenshot 2026-06-26 at 10 17 39" src="https://github.com/user-attachments/assets/73f70b49-d5bf-43bc-aa5d-32e99f0bc868" />

<img width="1203" height="601" alt="Screenshot 2026-06-26 at 10 17 57" src="https://github.com/user-attachments/assets/7e060a2b-5fe4-4549-aa6c-14fa608edcba" />
