### PR TITLE
Update CSS to allow filter to appear above results on zooming

### DIFF
--- a/assets/scss/overrides/_local.scss
+++ b/assets/scss/overrides/_local.scss
@@ -47,6 +47,39 @@
     width: 100%;
   }
 }
+
+// Responsive filter layout for accessibility
+.moj-filter {
+  max-width: 100%;
+}
+
+.caselist-filter-column,
+.group-filter-column {
+  flex-shrink: 1;
+  min-width: 0;
+}
+
+.caselist-results-column,
+.group-results-column {
+  flex-shrink: 1;
+  min-width: 0;
+}
+
+// Stack filter and results vertically when viewport is narrow
+// Allow users to see full filter options when zoomed in
+@media (max-width: 64em) {
+  .caselist-filter-column,
+  .caselist-results-column,
+  .group-filter-column,
+  .group-results-column{
+    width: 100%;
+  }
+
+  .caselist-filter-column,
+  .group-filter-column {
+    margin-bottom: 30px;
+  }
+}
 .govuk-tag.max-width-none {
   max-width: none;
 }

--- a/server/views/caselist/caselist.njk
+++ b/server/views/caselist/caselist.njk
@@ -38,7 +38,7 @@
     {{ govukSelectWithOptgroup(searchByStatusArgs) }}
 
     {% endset -%}
-    <div class="govuk-grid-column-one-quarter">
+    <div class="govuk-grid-column-one-quarter caselist-filter-column">
       <form method="get">
         {{ mojFilter({
           heading: {
@@ -56,7 +56,7 @@
         }) }}
       </form>
     </div>
-    <div class="govuk-grid-column-three-quarters">
+    <div class="govuk-grid-column-three-quarters caselist-results-column">
       {{ mojSubNavigation(subNavArgs) }}
       {% if resultsText %}
         <p class="govuk-body showing-results">{{ resultsText | safe }}</p>

--- a/server/views/group/group.njk
+++ b/server/views/group/group.njk
@@ -34,7 +34,7 @@
     {{ govukSelect(searchBySexArgs) }}
 
     {% endset -%}
-    <div class="govuk-grid-column-one-quarter">
+    <div class="govuk-grid-column-one-quarter group-filter-column">
       <form id="filter-form" method="get">
         {{ mojFilter({
           heading: {
@@ -50,7 +50,7 @@
         }) }}
       </form>
     </div>
-    <div class="govuk-grid-column-three-quarters">
+    <div class="govuk-grid-column-three-quarters group-results-column">
       {{ mojSubNavigation(subNavArgs) }}
       {% if resultsText %}
         <p class="govuk-body showing-results">{{ resultsText | safe }}</p>


### PR DESCRIPTION
Caselist and Group filters overlap the content when zoomed in
Fix to stack the filter over the results when the user is zoomed in or the viewport is small


Before
<img width="1850" height="883" alt="image" src="https://github.com/user-attachments/assets/f996e7b3-9461-4699-ad36-3beb37504e53" />
After
<img width="1920" height="4548" alt="image" src="https://github.com/user-attachments/assets/044c3f06-159f-47a0-947f-4330339f0219" />
