### PR TITLE
Improve hidden label to be more meaningful to screen readers

### DIFF
--- a/server/editSession/editSessionPresenter.test.ts
+++ b/server/editSession/editSessionPresenter.test.ts
@@ -89,6 +89,7 @@ describe('EditSessionPresenter', () => {
             {
               id: 'attendance-multi-select-row-0',
               value: '123',
+              checkBoxLabel: 'Alex River',
               cells: [
                 { html: '<a href="/referral-details/123/personal-details">Alex River</a> CRN001' },
                 { html: '<span class="govuk-tag govuk-tag--blue">Attended</span>' },
@@ -100,6 +101,7 @@ describe('EditSessionPresenter', () => {
             {
               id: 'attendance-multi-select-row-1',
               value: '456',
+              checkBoxLabel: 'Jane Doe',
               cells: [
                 { html: '<a href="/referral-details/456/personal-details">Jane Doe</a> CRN002' },
                 { html: '<span class="govuk-tag govuk-tag--red">Not attended</span>' },

--- a/server/editSession/editSessionPresenter.ts
+++ b/server/editSession/editSessionPresenter.ts
@@ -141,6 +141,7 @@ export default class EditSessionPresenter {
         rows: attendanceData.map((it, index) => ({
           id: `attendance-multi-select-row-${index}`,
           value: it.referralId,
+          checkBoxLabel: it.name,
           cells: [
             {
               html: `<a href="/referral-details/${it.referralId}/personal-details">${it.name}</a> ${it.crn}`,

--- a/server/views/components/multi-select/template.njk
+++ b/server/views/components/multi-select/template.njk
@@ -23,7 +23,7 @@
           <input type="checkbox" class="govuk-checkboxes__input" id="{{ idPrefix }}{{ row.id }}" name="{{ idPrefix }}selected" value="{{ row.id }}">
           {%- endif -%}
           <label class="govuk-label govuk-checkboxes__label" for="{{ idPrefix }}{{ row.id }}">
-            <span class="govuk-visually-hidden">Select {{ row.cells[0] }}</span>
+            <span class="govuk-visually-hidden">Select {{ row.checkBoxLabel }}</span>
           </label>
         </div>
       </td>


### PR DESCRIPTION
Improve the hidden text shown for screenreaders when selecting a check box on the attendance and session notes page

<img width="884" height="407" alt="Screenshot 2026-06-29 at 11 28 32" src="https://github.com/user-attachments/assets/24b76737-1d03-46d3-b5dd-f4cc9b5562d3" />
 

Before
``` html
<label for="person-1">
      <span class="govuk-visually-hidden">
        Select [object Object]
      </span>
 </label>
```
After
``` html
<label class="govuk-label govuk-checkboxes__label" for="multi-select-attendance-multi-select-row-1">
            <span class="govuk-visually-hidden">Select Aisha McGlynn</span>
          </label>
```