### PR TITLE
Wrap vertically instead of scrolling horizontally

### DIFF
--- a/assets/scss/overrides/_local.scss
+++ b/assets/scss/overrides/_local.scss
@@ -71,7 +71,7 @@
   .caselist-filter-column,
   .caselist-results-column,
   .group-filter-column,
-  .group-results-column{
+  .group-results-column {
     width: 100%;
   }
 
@@ -200,5 +200,16 @@
   &__service-name {
     display: inline-block;
   }
+}
+
+// Wrap text instead of horizontal scroll for accessibility
+.prisoner-info {
+  span {
+    text-wrap: auto;
+  }
+}
+
+.moj-side-navigation__list {
+  flex-wrap: wrap;
 }
 


### PR DESCRIPTION
Fixes to wrap content instead of horizontally scrolling when zoomed in
Before
<img width="1922" height="1046" alt="image" src="https://github.com/user-attachments/assets/0ccd2f7b-e12b-4ffa-bea0-863d5972f7c8" />

After
<img width="315" height="153" alt="Screenshot 2026-06-29 at 16 57 46" src="https://github.com/user-attachments/assets/68f2bb3a-0c9b-432c-8022-acface8cae0e" />

Before
<img width="1910" height="915" alt="image" src="https://github.com/user-attachments/assets/1aefdb64-8a47-487d-a48d-c00ddfa705e0" />

After
<img width="305" height="366" alt="Screenshot 2026-06-29 at 16 58 36" src="https://github.com/user-attachments/assets/e819ef1d-a13f-4658-9058-ba8d90ffbe41" />
