### PR TITLE
removed unintended hidden link

### DIFF
--- a/server/utils/viewUtils.ts
+++ b/server/utils/viewUtils.ts
@@ -148,14 +148,20 @@ export default class ViewUtils {
     return {
       card: (() => {
         if (options.showTitle) {
-          return {
+          const card: {
+            title?: { text?: string | null | undefined }
+            actions?: { items?: Array<{ href: string; text?: string | null; visuallyHiddenText?: string | null }> }
+          } = {
             title: {
               text: heading,
             },
-            actions: {
-              items: [actions],
-            },
           }
+          if (actions) {
+            card.actions = {
+              items: [actions],
+            }
+          }
+          return card
         }
         return null
       })(),


### PR DESCRIPTION
There was a hidden link in the Referral details page. Example: https://accredited-programmes-manage-and-deliver-dev.hmpps.service.justice.gov.uk/referral-details/f1fd3bc3-bdfb-4807-b6ad-eb66fd28eb57/personal-details

After you tabbed to 'Sentence information', there was another hidden link which has now been removed