### PR TITLE
hyphen and hint text amend

### DIFF
--- a/server/caselist/caselistController.test.ts
+++ b/server/caselist/caselistController.test.ts
@@ -43,8 +43,8 @@ describe(`Caselist controller`, () => {
     [`/region/open-referrals`, undefined, undefined, undefined, undefined],
     ['/region/closed-referrals', undefined, undefined, undefined, undefined],
     [
-      '/region/open-referrals?cohort=General offence - LDC&status=Programme+complete',
-      'General offence - LDC',
+      '/region/open-referrals?cohort=General offence LDC&status=Programme+complete',
+      'General offence LDC',
       'Programme complete',
       undefined,
       undefined,

--- a/server/caselist/caselistPresenter.test.ts
+++ b/server/caselist/caselistPresenter.test.ts
@@ -122,9 +122,9 @@ describe(`filters`, () => {
       expect(presenter.generateCohortSelectArgs()).toEqual([
         { text: 'Select', value: '' },
         { value: 'General offence', text: 'General offence', selected: false },
-        { value: 'General offence - LDC', text: 'General offence - LDC', selected: false },
+        { value: 'General offence LDC', text: 'General offence LDC', selected: false },
         { value: 'Sexual offence', text: 'Sexual offence', selected: false },
-        { value: 'Sexual offence - LDC', text: 'Sexual offence - LDC', selected: false },
+        { value: 'Sexual offence LDC', text: 'Sexual offence LDC', selected: false },
       ])
     })
 
@@ -150,9 +150,9 @@ describe(`filters`, () => {
       expect(presenter.generateCohortSelectArgs()).toEqual([
         { text: 'Select', value: '' },
         { value: 'General offence', text: 'General offence', selected: true },
-        { value: 'General offence - LDC', text: 'General offence - LDC', selected: false },
+        { value: 'General offence LDC', text: 'General offence LDC', selected: false },
         { value: 'Sexual offence', text: 'Sexual offence', selected: false },
-        { value: 'Sexual offence - LDC', text: 'Sexual offence - LDC', selected: false },
+        { value: 'Sexual offence LDC', text: 'Sexual offence LDC', selected: false },
       ])
     })
   })

--- a/server/editSession/dateAndTime/editSessionDateAndTimeView.ts
+++ b/server/editSession/dateAndTime/editSessionDateAndTimeView.ts
@@ -42,7 +42,7 @@ export default class EditSessionDateAndTimeView {
         },
       },
       hint: {
-        text: 'Use the 12-hour clock, for example 9:30am or 3pm. Enter 12pm for midday.',
+        text: 'Use the 12-hour clock, for example 9:30am or 3.00pm. Enter 12pm for midday.',
       },
       errorMessages: ViewUtils.govukErrorMessages(this.presenter.fields.startTime.errorMessages),
       items: [

--- a/server/editSession/dateAndTime/editSessionDateAndTimeView.ts
+++ b/server/editSession/dateAndTime/editSessionDateAndTimeView.ts
@@ -42,7 +42,7 @@ export default class EditSessionDateAndTimeView {
         },
       },
       hint: {
-        text: 'Use the 12-hour clock, for example 9:30am or 3:00pm. Enter 12pm for midday.',
+        text: 'Use the 12-hour clock, for example 9:30am or 3.00pm. Enter 12pm for midday.',
       },
       errorMessages: ViewUtils.govukErrorMessages(this.presenter.fields.startTime.errorMessages),
       items: [

--- a/server/editSession/dateAndTime/editSessionDateAndTimeView.ts
+++ b/server/editSession/dateAndTime/editSessionDateAndTimeView.ts
@@ -42,7 +42,7 @@ export default class EditSessionDateAndTimeView {
         },
       },
       hint: {
-        text: 'Use the 12-hour clock, for example 9:30am or 3.00pm. Enter 12pm for midday.',
+        text: 'Use the 12-hour clock, for example 9:30am or 3:00pm. Enter 12pm for midday.',
       },
       errorMessages: ViewUtils.govukErrorMessages(this.presenter.fields.startTime.errorMessages),
       items: [

--- a/server/group/groupPresenter.test.ts
+++ b/server/group/groupPresenter.test.ts
@@ -263,7 +263,7 @@ describe('captionClasses', () => {
 })
 
 describe('LDC cohort display', () => {
-  it('should display General offence - LDC with badge for GENERAL_LDC cohort', () => {
+  it('should display General offence LDC with badge for GENERAL_LDC cohort', () => {
     const groupList = groupsByRegionFactory.build()
     const ldcGroup = GroupFactory.build({ cohort: 'GENERAL_LDC' })
     groupList.pagedGroupData.content = [ldcGroup]
@@ -280,11 +280,11 @@ describe('LDC cohort display', () => {
 
     const tableArgs = presenter.groupTableArgs
     expect(tableArgs.rows[0][4]).toEqual({
-      html: 'General offence - LDC</br><span class="moj-badge moj-badge--bright-purple">LDC</span>',
+      html: 'General offence LDC</br><span class="moj-badge moj-badge--bright-purple">LDC</span>',
     })
   })
 
-  it('should display Sexual offence - LDC with badge for SEXUAL_LDC cohort', () => {
+  it('should display Sexual offence LDC with badge for SEXUAL_LDC cohort', () => {
     const groupList = groupsByRegionFactory.build()
     const ldcGroup = GroupFactory.build({ cohort: 'SEXUAL_LDC' })
     groupList.pagedGroupData.content = [ldcGroup]
@@ -301,7 +301,7 @@ describe('LDC cohort display', () => {
 
     const tableArgs = presenter.groupTableArgs
     expect(tableArgs.rows[0][4]).toEqual({
-      html: 'Sexual offence - LDC</br><span class="moj-badge moj-badge--bright-purple">LDC</span>',
+      html: 'Sexual offence LDC</br><span class="moj-badge moj-badge--bright-purple">LDC</span>',
     })
   })
 
@@ -345,16 +345,16 @@ describe('cohort filter select args', () => {
     expect(cohortSelectArgs).toEqual([
       { text: 'Select', value: '' },
       { value: 'General offence', text: 'General offence', selected: false },
-      { value: 'General offence - LDC', text: 'General offence - LDC', selected: false },
+      { value: 'General offence LDC', text: 'General offence LDC', selected: false },
       { value: 'Sexual offence', text: 'Sexual offence', selected: false },
-      { value: 'Sexual offence - LDC', text: 'Sexual offence - LDC', selected: false },
+      { value: 'Sexual offence LDC', text: 'Sexual offence LDC', selected: false },
     ])
   })
 
   it('should mark the selected cohort option as selected', () => {
     const groupList = groupsByRegionFactory.build()
     const filter = GroupListFilter.empty()
-    filter.cohort = 'General offence - LDC'
+    filter.cohort = 'General offence LDC'
 
     const presenter = new GroupPresenter(
       groupList.pagedGroupData as Page<Group>,
@@ -369,8 +369,8 @@ describe('cohort filter select args', () => {
     const cohortSelectArgs = presenter.generateCohortSelectArgs()
 
     expect(cohortSelectArgs[2]).toEqual({
-      value: 'General offence - LDC',
-      text: 'General offence - LDC',
+      value: 'General offence LDC',
+      text: 'General offence LDC',
       selected: true,
     })
   })
@@ -687,7 +687,7 @@ describe('cohort cell generation', () => {
     )
 
     expect(presenter.getCohortCell(group)).toEqual({
-      html: 'General offence - LDC</br><span class="moj-badge moj-badge--bright-purple">LDC</span>',
+      html: 'General offence LDC</br><span class="moj-badge moj-badge--bright-purple">LDC</span>',
     })
   })
 })

--- a/server/group/groupPresenter.ts
+++ b/server/group/groupPresenter.ts
@@ -8,8 +8,8 @@ import DateUtils from '../utils/dateUtils'
 const cohortConfigMap: Record<ProgrammeGroupCohortEnum, string> = {
   SEXUAL: 'Sexual offence',
   GENERAL: 'General offence',
-  GENERAL_LDC: 'General offence - LDC',
-  SEXUAL_LDC: 'Sexual offence - LDC',
+  GENERAL_LDC: 'General offence LDC',
+  SEXUAL_LDC: 'Sexual offence LDC',
 }
 
 export enum GroupListPageSection {
@@ -239,7 +239,7 @@ export default class GroupPresenter {
   }
 
   generateCohortSelectArgs(): SelectArgsItem[] {
-    const cohortOptions = ['General offence', 'General offence - LDC', 'Sexual offence', 'Sexual offence - LDC']
+    const cohortOptions = ['General offence', 'General offence LDC', 'Sexual offence', 'Sexual offence LDC']
     const selectOptions: SelectArgsItem[] = [
       {
         text: 'Select',

--- a/server/group/groupView.ts
+++ b/server/group/groupView.ts
@@ -76,7 +76,7 @@ export default class GroupView {
       },
       items: [
         {
-          text: 'Create a group',
+          text: 'Create group',
           classes: 'govuk-button--primary',
           href: '/create-group',
         },

--- a/server/sessionSchedule/sessionCya/sessionScheduleCyaView.ts
+++ b/server/sessionSchedule/sessionCya/sessionScheduleCyaView.ts
@@ -4,6 +4,10 @@ import SessionScheduleCyaPresenter from './SessionScheduleCyaPresenter'
 export default class SessionScheduleCyaView {
   constructor(private readonly presenter: SessionScheduleCyaPresenter) {}
 
+  private get isGroupSession(): boolean {
+    return this.presenter.createSessionDetails.groupOrOneToOne?.toUpperCase() === 'GROUP'
+  }
+
   private backLinkArgs() {
     return {
       text: 'Back',
@@ -81,7 +85,7 @@ export default class SessionScheduleCyaView {
         },
         {
           key: {
-            text: 'Participant',
+            text: this.isGroupSession ? 'Participants' : 'Participant',
           },
           value: {
             text: `${sessionDetails.referralName}`,
@@ -91,7 +95,7 @@ export default class SessionScheduleCyaView {
               {
                 href: editSessionDetailsUrl,
                 text: 'Change',
-                visuallyHiddenText: 'participant',
+                visuallyHiddenText: this.isGroupSession ? 'participants' : 'participant',
               },
             ],
           },

--- a/server/sessionSchedule/sessionDetails/addSessionDetailsView.ts
+++ b/server/sessionSchedule/sessionDetails/addSessionDetailsView.ts
@@ -47,7 +47,7 @@ export default class AddSessionDetailsView {
         },
       },
       hint: {
-        text: 'Use the 12-hour clock, for example 9:30am or 3:30pm. Enter 12:00pm for midday.',
+        text: 'Use the 12-hour clock, for example 9:30am or 3:00pm. Enter 12:00pm for midday.',
       },
       errorMessages: ViewUtils.govukErrorMessages(this.presenter.fields.startTime?.errorMessages),
       items: [

--- a/server/sessionSchedule/sessionDetails/addSessionDetailsView.ts
+++ b/server/sessionSchedule/sessionDetails/addSessionDetailsView.ts
@@ -173,7 +173,7 @@ export default class AddSessionDetailsView {
       name: 'session-details-who',
       fieldset: {
         legend: {
-          text: 'Who is this session for?',
+          text: 'Who is the session for?',
           isPageHeading: false,
           classes: 'govuk-fieldset__legend--m',
         },
@@ -191,13 +191,13 @@ export default class AddSessionDetailsView {
       name: 'session-details-who',
       fieldset: {
         legend: {
-          text: 'Who is this session for?',
+          text: 'Who is the session for?',
           isPageHeading: false,
           classes: 'govuk-fieldset__legend--m',
         },
       },
       hint: {
-        text: 'Select everyone who should attend this session.',
+        text: 'Select everyone who should attend the session.',
       },
       errorMessage: ViewUtils.govukErrorMessage(this.presenter.fields.who.errorMessage),
       items: this.presenter.generateSessionAttendeesCheckboxOptions(this.presenter.selectedAttendeeValues()),

--- a/server/testutils/factories/programmeGroupAllocationsFactory.ts
+++ b/server/testutils/factories/programmeGroupAllocationsFactory.ts
@@ -144,7 +144,7 @@ export default ProgrammeGroupAllocationsFactory.define(() => ({
   },
   filters: {
     sex: ['Male', 'Female'],
-    cohort: ['General Offence', 'General Offence - LDC', 'Sexual Offence', 'Sexual Offence - LDC'],
+    cohort: ['General Offence', 'General Offence LDC', 'Sexual Offence', 'Sexual Offence LDC'],
     locationFilters: [
       {
         pduName: 'Manchester',

--- a/server/testutils/testUtils.ts
+++ b/server/testutils/testUtils.ts
@@ -64,6 +64,6 @@ export default class TestUtils {
         reportingTeams: ['Team5'],
       },
     ],
-    cohort: ['General offence', 'General offence - LDC', 'Sexual offence', 'Sexual offence - LDC'],
+    cohort: ['General offence', 'General offence LDC', 'Sexual offence', 'Sexual offence LDC'],
   })
 }

--- a/server/views/createGroup/createGroupCya.njk
+++ b/server/views/createGroup/createGroupCya.njk
@@ -25,7 +25,6 @@
                             {{ govukSummaryList(createGroupSummary) }}
                             <div class="govuk-button-group">
                                 {{ govukButton({ text: "Create this group", preventDoubleClick: true }) }}
-                                <a class="govuk-link" href={{ cancelLink }}>Cancel</a>
                             </div>
                         </form>
                     </div>


### PR DESCRIPTION
This PR contains lots of small changes from the design review.

Hypens removed from 'General offence - LDC' and 'Sexual offence - LDC'
'Create a group' button  changed to 'Create group' ('a' removed)
Start time changed to 3:00
Participants (plural) added for groups
'Who is this session for?' change to 'Who is **the** session for?'
Cancel button removed