### PR TITLE
Plural or singular text in results

### DIFF
--- a/server/caselist/caselistPresenter.test.ts
+++ b/server/caselist/caselistPresenter.test.ts
@@ -666,6 +666,21 @@ describe('generateNoResultsString', () => {
     expect(presenter.generateNoResultsString()).toBe('No results in open referrals. 3 results in closed referrals.')
   })
 
+  it('returns singular result wording when closed count is one on open section', () => {
+    const presenter = new CaselistPresenter(
+      1,
+      emptyPage,
+      {} as CaselistFilter,
+      '',
+      true,
+      TestUtils.createCaseListFilters(),
+      1,
+      'test location',
+    )
+
+    expect(presenter.generateNoResultsString()).toBe('No results in open referrals. 1 result in closed referrals.')
+  })
+
   it('returns closed-referrals message with open count when on closed section', () => {
     const presenter = new CaselistPresenter(
       2,
@@ -679,6 +694,21 @@ describe('generateNoResultsString', () => {
     )
 
     expect(presenter.generateNoResultsString()).toBe('No results in closed referrals. 5 results in open referrals.')
+  })
+
+  it('returns singular result wording when open count is one on closed section', () => {
+    const presenter = new CaselistPresenter(
+      2,
+      emptyPage,
+      {} as CaselistFilter,
+      '',
+      false,
+      TestUtils.createCaseListFilters(),
+      1,
+      'test location',
+    )
+
+    expect(presenter.generateNoResultsString()).toBe('No results in closed referrals. 1 result in open referrals.')
   })
 
   it('returns clear-filters guidance for closed section when other count is zero', () => {

--- a/server/caselist/caselistPresenter.ts
+++ b/server/caselist/caselistPresenter.ts
@@ -247,13 +247,17 @@ export default class CaselistPresenter {
   }
 
   generateNoResultsString(): string {
+    const count = this.otherCaselistCountTotal
+    const resultsText = `${count} ${count === 1 ? 'result' : 'results'}`
+
     if (this.section === CaselistPageSection.Open) {
-      return this.otherCaselistCountTotal === 0
+      return count === 0
         ? 'No results found. Clear or change the filters.'
-        : `No results in open referrals. ${this.otherCaselistCountTotal} results in closed referrals.`
+        : `No results in open referrals. ${resultsText} in closed referrals.`
     }
-    return this.otherCaselistCountTotal === 0
+
+    return count === 0
       ? 'No results found. Clear or change the filters.'
-      : `No results in closed referrals. ${this.otherCaselistCountTotal} results in open referrals.`
+      : `No results in closed referrals. ${resultsText} in open referrals.`
   }
 }


### PR DESCRIPTION
Shows the word 'result' instead of 'results' when there is only 1 result.

<img width="1260" height="556" alt="Screenshot 2026-07-03 at 09 10 51" src="https://github.com/user-attachments/assets/3eae66a1-bc28-4b0d-9153-11cd44fe0fdc" />
