### PR TITLE
check your answers page change destination

### DIFF
--- a/server/createGroup/check-your-answers/createGroupCyaPresenter.test.ts
+++ b/server/createGroup/check-your-answers/createGroupCyaPresenter.test.ts
@@ -219,55 +219,55 @@ describe('CreateGroupCyaPresenter', () => {
       expect(summary).toContainEqual({
         key: 'Group code',
         lines: ['ABC123'],
-        changeLink: '/create-group-code',
+        changeLink: '/create-group-code?referrer=group-review-details',
         visuallyHiddenText: 'group code',
       })
       expect(summary).toContainEqual({
         key: 'Start date',
         lines: ['2026-06-01'],
-        changeLink: '/group-start-date',
+        changeLink: '/group-start-date?referrer=group-review-details',
         visuallyHiddenText: 'start date',
       })
       expect(summary).toContainEqual({
         key: 'Days and times',
         lines: ['Monday 2:00 PM - 4:00 PM'],
-        changeLink: '/group-days-and-times',
+        changeLink: '/group-days-and-times?referrer=group-review-details',
         visuallyHiddenText: 'days and times',
       })
       expect(summary).toContainEqual({
         key: 'Cohort',
         lines: ['General offence'],
-        changeLink: '/group-cohort',
+        changeLink: '/group-cohort?referrer=group-review-details',
         visuallyHiddenText: 'cohort',
       })
       expect(summary).toContainEqual({
         key: 'Gender',
         lines: ['Male'],
-        changeLink: '/group-gender',
+        changeLink: '/group-gender?referrer=group-review-details',
         visuallyHiddenText: 'gender',
       })
       expect(summary).toContainEqual({
         key: 'PDU',
         lines: ['PDU North'],
-        changeLink: '/group-probation-delivery-unit',
+        changeLink: '/group-probation-delivery-unit?referrer=group-review-details',
         visuallyHiddenText: 'PDU',
       })
       expect(summary).toContainEqual({
         key: 'Delivery location',
         lines: ['Prison A'],
-        changeLink: '/group-delivery-location',
+        changeLink: '/group-delivery-location?referrer=group-review-details',
         visuallyHiddenText: 'delivery location',
       })
       expect(summary).toContainEqual({
         key: 'Treatment Manager',
         lines: ['Not assigned'],
-        changeLink: '/group-facilitators',
+        changeLink: '/group-facilitators?referrer=group-review-details',
         visuallyHiddenText: 'treatment manager',
       })
       expect(summary).toContainEqual({
         key: 'Facilitators',
         lines: ['None assigned'],
-        changeLink: '/group-facilitators',
+        changeLink: '/group-facilitators?referrer=group-review-details',
         visuallyHiddenText: 'facilitators',
       })
     })
@@ -297,7 +297,7 @@ describe('CreateGroupCyaPresenter', () => {
       expect(summary).toContainEqual({
         key: 'Treatment Manager',
         lines: ['John Smith'],
-        changeLink: '/group-facilitators',
+        changeLink: '/group-facilitators?referrer=group-review-details',
         visuallyHiddenText: 'treatment manager',
       })
     })
@@ -334,7 +334,7 @@ describe('CreateGroupCyaPresenter', () => {
       expect(summary).toContainEqual({
         key: 'Facilitators',
         lines: ['Jane Doe', 'Bob Johnson'],
-        changeLink: '/group-facilitators',
+        changeLink: '/group-facilitators?referrer=group-review-details',
         visuallyHiddenText: 'facilitators',
       })
     })
@@ -390,7 +390,7 @@ describe('CreateGroupCyaPresenter', () => {
       expect(summary).toContainEqual({
         key: 'Cover facilitators',
         lines: ['Alice Brown', 'Charlie Wilson'],
-        changeLink: '/group-facilitators',
+        changeLink: '/group-facilitators?referrer=group-review-details',
         visuallyHiddenText: 'cover facilitators',
       })
     })
@@ -443,7 +443,7 @@ describe('CreateGroupCyaPresenter', () => {
       expect(summary).toContainEqual({
         key: 'Days and times',
         lines: ['Monday 2:00 PM - 4:00 PM', 'Wednesday 10:00 AM - 12:00 PM'],
-        changeLink: '/group-days-and-times',
+        changeLink: '/group-days-and-times?referrer=group-review-details',
         visuallyHiddenText: 'days and times',
       })
     })

--- a/server/createGroup/check-your-answers/createGroupCyaPresenter.ts
+++ b/server/createGroup/check-your-answers/createGroupCyaPresenter.ts
@@ -20,6 +20,10 @@ export default class CreateGroupCyaPresenter {
     return 'Review your group details'
   }
 
+  private changeLinkUri(path: string): string {
+    return `${path}?referrer=group-review-details`
+  }
+
   generateSelectedUsers(): {
     treatmentManager: CreateGroupTeamMember | undefined
     facilitators: CreateGroupTeamMember[] | []
@@ -52,58 +56,58 @@ export default class CreateGroupCyaPresenter {
       {
         key: 'Group code',
         lines: [`${this.createGroupFormData.groupCode}`],
-        changeLink: '/create-group-code',
+        changeLink: this.changeLinkUri('/create-group-code'),
         visuallyHiddenText: 'group code',
       },
       {
         key: 'Start date',
         lines: [`${this.createGroupFormData.earliestStartDate}`],
-        changeLink: '/group-start-date',
+        changeLink: this.changeLinkUri('/group-start-date'),
         visuallyHiddenText: 'start date',
       },
 
       {
         key: 'Days and times',
         lines: GroupDaysTimesUtils.formatStartDaysAndTimes(this.createGroupFormData.createGroupSessionSlot),
-        changeLink: '/group-days-and-times',
+        changeLink: this.changeLinkUri('/group-days-and-times'),
         visuallyHiddenText: 'days and times',
       },
 
       {
         key: 'Cohort',
         lines: [`${this.createGroupUtils.getCohortTextFromEnum(this.createGroupFormData.cohort)}`],
-        changeLink: '/group-cohort',
+        changeLink: this.changeLinkUri('/group-cohort'),
         visuallyHiddenText: 'cohort',
       },
       {
         key: 'Gender',
         lines: [`${this.createGroupUtils.getSexTextFromEnum(this.createGroupFormData.sex)}`],
-        changeLink: '/group-gender',
+        changeLink: this.changeLinkUri('/group-gender'),
         visuallyHiddenText: 'gender',
       },
       {
         key: 'PDU',
         lines: [`${this.createGroupFormData.pduName}`],
-        changeLink: '/group-probation-delivery-unit',
+        changeLink: this.changeLinkUri('/group-probation-delivery-unit'),
         visuallyHiddenText: 'PDU',
       },
       {
         key: 'Delivery location',
         lines: [`${this.createGroupFormData.deliveryLocationName}`],
-        changeLink: '/group-delivery-location',
+        changeLink: this.changeLinkUri('/group-delivery-location'),
         visuallyHiddenText: 'delivery location',
       },
       {
         key: 'Treatment Manager',
         lines: [members.treatmentManager?.facilitator ?? 'Not assigned'],
-        changeLink: '/group-facilitators',
+        changeLink: this.changeLinkUri('/group-facilitators'),
         visuallyHiddenText: 'treatment manager',
       },
       {
         key: 'Facilitators',
         lines:
           members.facilitators.length > 0 ? members.facilitators.map(member => member.facilitator) : ['None assigned'],
-        changeLink: '/group-facilitators',
+        changeLink: this.changeLinkUri('/group-facilitators'),
         visuallyHiddenText: 'facilitators',
       },
     ]
@@ -114,7 +118,7 @@ export default class CreateGroupCyaPresenter {
           members.coverFacilitators.length > 0
             ? members.coverFacilitators.map(member => member.facilitator)
             : ['None assigned'],
-        changeLink: '/group-facilitators',
+        changeLink: this.changeLinkUri('/group-facilitators'),
         visuallyHiddenText: 'cover facilitators',
       })
     }

--- a/server/createGroup/check-your-answers/createGroupCyaPresenter.ts
+++ b/server/createGroup/check-your-answers/createGroupCyaPresenter.ts
@@ -21,7 +21,9 @@ export default class CreateGroupCyaPresenter {
   }
 
   private changeLinkUri(path: string): string {
-    return `${path}?referrer=group-review-details`
+    // return `${path}?referrer=group-review-details`
+    const separator = path.includes('?') ? '&' : '?'
+    return `${path}${separator}referrer=group-review-details`
   }
 
   generateSelectedUsers(): {

--- a/server/createGroup/check-your-answers/createGroupCyaPresenter.ts
+++ b/server/createGroup/check-your-answers/createGroupCyaPresenter.ts
@@ -21,7 +21,6 @@ export default class CreateGroupCyaPresenter {
   }
 
   private changeLinkUri(path: string): string {
-    // return `${path}?referrer=group-review-details`
     const separator = path.includes('?') ? '&' : '?'
     return `${path}${separator}referrer=group-review-details`
   }

--- a/server/createGroup/cohort/createOrEditGroupCohortPresenter.test.ts
+++ b/server/createGroup/cohort/createOrEditGroupCohortPresenter.test.ts
@@ -48,7 +48,7 @@ describe('CreateOrEditGroupCohortPresenter', () => {
       }
       const presenter = new CreateOrEditGroupCohortPresenter(null, createGroupFormData, null, undefined)
 
-      expect(presenter.captionText).toEqual('Create a group NEW-GROUP-001')
+      expect(presenter.captionText).toEqual('Create group NEW-GROUP-001')
     })
   })
 

--- a/server/createGroup/cohort/createOrEditGroupCohortPresenter.ts
+++ b/server/createGroup/cohort/createOrEditGroupCohortPresenter.ts
@@ -20,7 +20,7 @@ export default class CreateOrEditGroupCohortPresenter {
   }
 
   get captionText() {
-    return this.isEditJourney ? `Edit group ${this.groupCode}` : `Create a group ${this.createGroupFormData.groupCode}`
+    return this.isEditJourney ? `Edit group ${this.groupCode}` : `Create group ${this.createGroupFormData.groupCode}`
   }
 
   get pageTitle() {

--- a/server/createGroup/createGroupController.test.ts
+++ b/server/createGroup/createGroupController.test.ts
@@ -387,7 +387,7 @@ describe('Create Group Controller', () => {
         })
     })
 
-    it('redirects back to review when submitted from the check your answers pdu change link', async () => {
+    it('redirects to delivery location with review referrer when submitted from the check your answers probation delivery unit change link', async () => {
       accreditedProgrammesManageAndDeliverService.getLocationsForUserRegion.mockResolvedValue([
         { code: 'LDN', description: 'London' },
       ])
@@ -399,7 +399,41 @@ describe('Create Group Controller', () => {
         })
         .expect(302)
         .expect(res => {
-          expect(res.text).toContain('Redirecting to /group-review-details')
+          expect(res.text).toContain('Redirecting to /group-delivery-location?referrer=group-review-details')
+        })
+    })
+
+    it('clears any previously selected delivery location when the probation delivery unit changes', async () => {
+      const sessionData: Partial<SessionData> = {
+        createGroupFormData: {
+          pduName: 'Old PDU',
+          pduCode: 'OLD',
+          deliveryLocationName: 'Old Location',
+          deliveryLocationCode: 'OLD-LOC',
+        },
+      }
+      app = TestUtils.createTestAppWithSession(sessionData, { accreditedProgrammesManageAndDeliverService })
+      accreditedProgrammesManageAndDeliverService.getLocationsForUserRegion.mockResolvedValue([
+        { code: 'LDN', description: 'London' },
+      ])
+      accreditedProgrammesManageAndDeliverService.getOfficeLocationsForPdu.mockResolvedValue([
+        { code: 'WMO', description: 'Westminster Office' },
+      ])
+
+      await request(app)
+        .post('/group-probation-delivery-unit')
+        .type('form')
+        .send({
+          'create-group-pdu': '{"code":"LDN", "name":"London"}',
+        })
+        .expect(302)
+
+      return request(app)
+        .get('/group-delivery-location')
+        .expect(200)
+        .expect(res => {
+          expect(res.text).toContain('Westminster Office')
+          expect(res.text).not.toContain('checked')
         })
     })
 
@@ -456,7 +490,7 @@ describe('Create Group Controller', () => {
   })
 
   describe('POST /group-delivery-location', () => {
-    it('redirects to check your answers page on successful submission', async () => {
+    it('redirects to facilitators page on successful submission', async () => {
       accreditedProgrammesManageAndDeliverService.getOfficeLocationsForPdu.mockResolvedValue([
         { code: 'LDN', description: 'London' },
       ])
@@ -472,7 +506,7 @@ describe('Create Group Controller', () => {
         })
     })
 
-    it('redirects back to review when submitted from the check your answers delivery location change link', async () => {
+    it('redirects to review when submitted from the check your answers delivery location change link', async () => {
       accreditedProgrammesManageAndDeliverService.getOfficeLocationsForPdu.mockResolvedValue([
         { code: 'LDN', description: 'London' },
       ])

--- a/server/createGroup/createGroupController.test.ts
+++ b/server/createGroup/createGroupController.test.ts
@@ -109,6 +109,17 @@ describe('Create Group Controller', () => {
         })
     })
 
+    it('redirects back to review when submitted from a check your answers change link', async () => {
+      return request(app)
+        .post('/create-group-code?referrer=group-review-details')
+        .type('form')
+        .send({ 'create-group-code': 'ABC123' })
+        .expect(302)
+        .expect(res => {
+          expect(res.text).toContain('Redirecting to /group-review-details')
+        })
+    })
+
     // A 404 from code lookup means no existing group has this code, so the journey can continue.
     it('continues to start date page when group code lookup returns 404 (code not in use)', async () => {
       accreditedProgrammesManageAndDeliverService.getGroupByCodeInRegion.mockRejectedValue({ status: 404 })
@@ -172,6 +183,17 @@ describe('Create Group Controller', () => {
         .expect(302)
         .expect(res => {
           expect(res.text).toContain('Redirecting to /group-days-and-times')
+        })
+    })
+
+    it('redirects back to review when submitted from a check your answers change link', async () => {
+      return request(app)
+        .post('/group-start-date?referrer=group-review-details')
+        .type('form')
+        .send({ 'create-group-date': '10/7/2050' })
+        .expect(302)
+        .expect(res => {
+          expect(res.text).toContain('Redirecting to /group-review-details')
         })
     })
 
@@ -365,6 +387,22 @@ describe('Create Group Controller', () => {
         })
     })
 
+    it('redirects back to review when submitted from a check your answers change link', async () => {
+      accreditedProgrammesManageAndDeliverService.getLocationsForUserRegion.mockResolvedValue([
+        { code: 'LDN', description: 'London' },
+      ])
+      return request(app)
+        .post('/group-probation-delivery-unit?referrer=group-review-details')
+        .type('form')
+        .send({
+          'create-group-pdu': '{"code":"LDN", "name":"London"}',
+        })
+        .expect(302)
+        .expect(res => {
+          expect(res.text).toContain('Redirecting to /group-review-details')
+        })
+    })
+
     it('returns with errors if pdu is not selected', async () => {
       accreditedProgrammesManageAndDeliverService.getLocationsForUserRegion.mockResolvedValue([
         { code: 'LDN', description: 'London' },
@@ -431,6 +469,22 @@ describe('Create Group Controller', () => {
         .expect(302)
         .expect(res => {
           expect(res.text).toContain('Redirecting to /group-facilitators')
+        })
+    })
+
+    it('redirects back to review when submitted from a check your answers change link', async () => {
+      accreditedProgrammesManageAndDeliverService.getOfficeLocationsForPdu.mockResolvedValue([
+        { code: 'LDN', description: 'London' },
+      ])
+      return request(app)
+        .post('/group-delivery-location?referrer=group-review-details')
+        .type('form')
+        .send({
+          'create-group-location': '{ "code": "WMO", "name": "Westminster Office" }',
+        })
+        .expect(302)
+        .expect(res => {
+          expect(res.text).toContain('Redirecting to /group-review-details')
         })
     })
 

--- a/server/createGroup/createGroupController.test.ts
+++ b/server/createGroup/createGroupController.test.ts
@@ -109,7 +109,7 @@ describe('Create Group Controller', () => {
         })
     })
 
-    it('redirects back to review when submitted from a check your answers change link', async () => {
+    it('redirects back to review when submitted from the check your answers group code change link', async () => {
       return request(app)
         .post('/create-group-code?referrer=group-review-details')
         .type('form')
@@ -186,7 +186,7 @@ describe('Create Group Controller', () => {
         })
     })
 
-    it('redirects back to review when submitted from a check your answers change link', async () => {
+    it('redirects back to review when submitted from the check your answers start date change link', async () => {
       return request(app)
         .post('/group-start-date?referrer=group-review-details')
         .type('form')
@@ -387,7 +387,7 @@ describe('Create Group Controller', () => {
         })
     })
 
-    it('redirects back to review when submitted from a check your answers change link', async () => {
+    it('redirects back to review when submitted from the check your answers pdu change link', async () => {
       accreditedProgrammesManageAndDeliverService.getLocationsForUserRegion.mockResolvedValue([
         { code: 'LDN', description: 'London' },
       ])
@@ -472,7 +472,7 @@ describe('Create Group Controller', () => {
         })
     })
 
-    it('redirects back to review when submitted from a check your answers change link', async () => {
+    it('redirects back to review when submitted from the check your answers delivery location change link', async () => {
       accreditedProgrammesManageAndDeliverService.getOfficeLocationsForPdu.mockResolvedValue([
         { code: 'LDN', description: 'London' },
       ])

--- a/server/createGroup/createGroupController.test.ts
+++ b/server/createGroup/createGroupController.test.ts
@@ -487,6 +487,19 @@ describe('Create Group Controller', () => {
           expect(res.text).toContain('Whitehall Office')
         })
     })
+
+    it('preserves review referrer on the PDU change link when loaded from check your answers', async () => {
+      accreditedProgrammesManageAndDeliverService.getOfficeLocationsForPdu.mockResolvedValue([
+        { code: 'WMO', description: 'Westminster Office' },
+      ])
+
+      return request(app)
+        .get('/group-delivery-location?referrer=group-review-details')
+        .expect(200)
+        .expect(res => {
+          expect(res.text).toContain('href="/group-probation-delivery-unit?referrer=group-review-details"')
+        })
+    })
   })
 
   describe('POST /group-delivery-location', () => {
@@ -510,6 +523,55 @@ describe('Create Group Controller', () => {
       accreditedProgrammesManageAndDeliverService.getOfficeLocationsForPdu.mockResolvedValue([
         { code: 'LDN', description: 'London' },
       ])
+      return request(app)
+        .post('/group-delivery-location?referrer=group-review-details')
+        .type('form')
+        .send({
+          'create-group-location': '{ "code": "WMO", "name": "Westminster Office" }',
+        })
+        .expect(302)
+        .expect(res => {
+          expect(res.text).toContain('Redirecting to /group-review-details')
+        })
+    })
+
+    it('redirects to review after changing PDU from delivery location in a check your answers change journey', async () => {
+      accreditedProgrammesManageAndDeliverService.getLocationsForUserRegion.mockResolvedValue([
+        { code: 'LDN', description: 'London' },
+      ])
+      accreditedProgrammesManageAndDeliverService.getOfficeLocationsForPdu.mockResolvedValue([
+        { code: 'WMO', description: 'Westminster Office' },
+      ])
+
+      await request(app)
+        .post('/group-probation-delivery-unit?referrer=group-review-details')
+        .type('form')
+        .send({
+          'create-group-pdu': '{"code":"LDN", "name":"London"}',
+        })
+        .expect(302)
+        .expect(res => {
+          expect(res.text).toContain('Redirecting to /group-delivery-location?referrer=group-review-details')
+        })
+
+      await request(app)
+        .get('/group-delivery-location?referrer=group-review-details')
+        .expect(200)
+        .expect(res => {
+          expect(res.text).toContain('href="/group-probation-delivery-unit?referrer=group-review-details"')
+        })
+
+      await request(app)
+        .post('/group-probation-delivery-unit?referrer=group-review-details')
+        .type('form')
+        .send({
+          'create-group-pdu': '{"code":"LDN", "name":"London"}',
+        })
+        .expect(302)
+        .expect(res => {
+          expect(res.text).toContain('Redirecting to /group-delivery-location?referrer=group-review-details')
+        })
+
       return request(app)
         .post('/group-delivery-location?referrer=group-review-details')
         .type('form')

--- a/server/createGroup/createGroupController.ts
+++ b/server/createGroup/createGroupController.ts
@@ -36,7 +36,8 @@ export default class CreateGroupController extends BaseController {
   }
 
   private isReturningFromReview(req: Request): boolean {
-    return req.query.referrer === 'group-review-details'
+    const referrer = Array.isArray(req.query.referrer) ? req.query.referrer[0] : req.query.referrer
+    return referrer === 'group-review-details'
   }
 
   private nextCreateGroupRedirect(req: Request, defaultPath: string): string {

--- a/server/createGroup/createGroupController.ts
+++ b/server/createGroup/createGroupController.ts
@@ -228,8 +228,13 @@ export default class CreateGroupController extends BaseController {
           ...createGroupFormData,
           pduName: data.paramsForUpdate.pduName,
           pduCode: data.paramsForUpdate.pduCode,
+          deliveryLocationName: undefined,
+          deliveryLocationCode: undefined,
         }
-        return res.redirect(this.nextCreateGroupRedirect(req, '/group-delivery-location'))
+        const deliveryLocationPath = this.isReturningFromReview(req)
+          ? '/group-delivery-location?referrer=group-review-details'
+          : '/group-delivery-location'
+        return res.redirect(deliveryLocationPath)
       }
     }
 

--- a/server/createGroup/createGroupController.ts
+++ b/server/createGroup/createGroupController.ts
@@ -277,6 +277,10 @@ export default class CreateGroupController extends BaseController {
       formError,
       createGroupFormData,
       userInputData,
+      null,
+      false,
+      null,
+      this.isReturningFromReview(req),
     )
     const view = new CreateOrEditGroupLocationView(presenter)
     return this.renderPage(res, view)

--- a/server/createGroup/createGroupController.ts
+++ b/server/createGroup/createGroupController.ts
@@ -35,6 +35,14 @@ export default class CreateGroupController extends BaseController {
     super()
   }
 
+  private isReturningFromReview(req: Request): boolean {
+    return req.query.referrer === 'group-review-details'
+  }
+
+  private nextCreateGroupRedirect(req: Request, defaultPath: string): string {
+    return this.isReturningFromReview(req) ? '/group-review-details' : defaultPath
+  }
+
   async showCreateGroupStart(req: Request, res: Response): Promise<void> {
     if (req.method === 'POST') {
       return res.redirect('/create-group-code')
@@ -79,7 +87,7 @@ export default class CreateGroupController extends BaseController {
           ...createGroupFormData,
           groupCode: data.paramsForUpdate.groupCode,
         }
-        return res.redirect(`/group-start-date`)
+        return res.redirect(this.nextCreateGroupRedirect(req, '/group-start-date'))
       }
     }
 
@@ -111,7 +119,7 @@ export default class CreateGroupController extends BaseController {
           ...createGroupFormData,
           earliestStartDate: data.paramsForUpdate.earliestStartDate,
         }
-        return res.redirect(`/group-days-and-times`)
+        return res.redirect(this.nextCreateGroupRedirect(req, '/group-days-and-times'))
       }
     }
 
@@ -143,7 +151,7 @@ export default class CreateGroupController extends BaseController {
         formError = data.error
         userInputData = req.body
       } else {
-        return res.redirect(`/group-cohort`)
+        return res.redirect(this.nextCreateGroupRedirect(req, '/group-cohort'))
       }
     }
 
@@ -172,7 +180,7 @@ export default class CreateGroupController extends BaseController {
           ...createGroupFormData,
           cohort: data.paramsForUpdate.cohort,
         }
-        return res.redirect(`/group-gender`)
+        return res.redirect(this.nextCreateGroupRedirect(req, '/group-gender'))
       }
     }
 
@@ -194,7 +202,7 @@ export default class CreateGroupController extends BaseController {
           ...createGroupFormData,
           sex: data.paramsForUpdate.sex,
         }
-        return res.redirect(`/group-probation-delivery-unit`)
+        return res.redirect(this.nextCreateGroupRedirect(req, '/group-probation-delivery-unit'))
       }
     }
     const presenter = new CreateOrEditGroupGenderPresenter(formError, createGroupFormData)
@@ -220,7 +228,7 @@ export default class CreateGroupController extends BaseController {
           pduName: data.paramsForUpdate.pduName,
           pduCode: data.paramsForUpdate.pduCode,
         }
-        return res.redirect(`/group-delivery-location`)
+        return res.redirect(this.nextCreateGroupRedirect(req, '/group-delivery-location'))
       }
     }
 
@@ -249,7 +257,7 @@ export default class CreateGroupController extends BaseController {
           deliveryLocationName: data.paramsForUpdate.deliveryLocationName,
           deliveryLocationCode: data.paramsForUpdate.deliveryLocationCode,
         }
-        return res.redirect(`/group-facilitators`)
+        return res.redirect(this.nextCreateGroupRedirect(req, '/group-facilitators'))
       }
     }
 
@@ -285,7 +293,7 @@ export default class CreateGroupController extends BaseController {
           ...createGroupFormData,
           teamMembers: data.paramsForUpdate.teamMembers,
         }
-        return res.redirect(`/group-review-details`)
+        return res.redirect(this.nextCreateGroupRedirect(req, '/group-review-details'))
       }
     }
 

--- a/server/createGroup/location/createOrEditGroupLocationPresenter.test.ts
+++ b/server/createGroup/location/createOrEditGroupLocationPresenter.test.ts
@@ -68,6 +68,21 @@ describe('CreateOrEditGroupLocationPresenter', () => {
 
       expect(presenter.changeLinkUri).toEqual('/group-probation-delivery-unit')
     })
+
+    it('returns create group PDU link with review referrer when configured in create journey', () => {
+      const presenter = new CreateOrEditGroupLocationPresenter(
+        mockLocations,
+        null,
+        { groupCode: 'TEST-GROUP-001' },
+        null,
+        null,
+        false,
+        null,
+        true,
+      )
+
+      expect(presenter.changeLinkUri).toEqual('/group-probation-delivery-unit?referrer=group-review-details')
+    })
   })
 
   describe('pageTitle', () => {

--- a/server/createGroup/location/createOrEditGroupLocationPresenter.ts
+++ b/server/createGroup/location/createOrEditGroupLocationPresenter.ts
@@ -12,6 +12,7 @@ export default class CreateOrEditGroupLocationPresenter {
     private readonly groupId: string | null = null,
     readonly isEditJourney = false,
     private readonly backLink: string | null = null,
+    private readonly includeReviewReferrer = false,
   ) {}
 
   get backLinkUri() {
@@ -23,7 +24,13 @@ export default class CreateOrEditGroupLocationPresenter {
   }
 
   get changeLinkUri() {
-    return this.isEditJourney ? `/${this.groupId}/edit-group-probation-delivery-unit` : `/group-probation-delivery-unit`
+    if (this.isEditJourney) {
+      return `/${this.groupId}/edit-group-probation-delivery-unit`
+    }
+
+    return this.includeReviewReferrer
+      ? '/group-probation-delivery-unit?referrer=group-review-details'
+      : '/group-probation-delivery-unit'
   }
 
   get text() {


### PR DESCRIPTION
Change links take users to the correct page but then make them step through the whole journey again rather than sending them back to the review page after they've edited that page. Should work that eg, you click the change link next to cohort, it sends you to the cohort page to edit, and then back to the review page when you click ‘Continue’.