### PR TITLE
Fix invalid subjectIds in audits causing DLQs

### DIFF
--- a/server/caselist/caselistController.test.ts
+++ b/server/caselist/caselistController.test.ts
@@ -72,13 +72,16 @@ describe(`Caselist controller`, () => {
           expect(sendAuditEvent).toHaveBeenCalledWith(
             url.startsWith('/region/open-referrals') ? 'SEARCH_OPEN_CASELIST' : 'SEARCH_CLOSED_CASELIST',
             'user1',
-            JSON.stringify({
-              pdu: pduValue,
-              reportingTeam: reportingTeamValue ? [reportingTeamValue] : undefined,
-              status: referralStatusValue,
-              cohort: cohortValue,
-            }),
-            'SEARCH_TERM',
+            undefined,
+            'NOT_APPLICABLE',
+            {
+              filter: {
+                pdu: pduValue,
+                reportingTeam: reportingTeamValue ? [reportingTeamValue] : undefined,
+                status: referralStatusValue,
+                cohort: cohortValue,
+              },
+            },
           )
         })
     },

--- a/server/caselist/caselistController.ts
+++ b/server/caselist/caselistController.ts
@@ -35,7 +35,9 @@ export default class CaselistController extends BaseController {
     const pageNumber = req.query.page
 
     const requestedFilter = CaselistFilter.fromRequest(req)
-    await sendAuditEvent('SEARCH_OPEN_CASELIST', username, JSON.stringify(requestedFilter.params), 'SEARCH_TERM')
+    await sendAuditEvent('SEARCH_OPEN_CASELIST', username, undefined, 'NOT_APPLICABLE', {
+      filter: requestedFilter.params,
+    })
     let openCaseList = await this.accreditedProgrammesManageAndDeliverService.getOpenCaselist(
       username,
       {
@@ -83,7 +85,9 @@ export default class CaselistController extends BaseController {
     const pageNumber = req.query.page
 
     const requestedFilter = CaselistFilter.fromRequest(req)
-    await sendAuditEvent('SEARCH_CLOSED_CASELIST', username, JSON.stringify(requestedFilter.params), 'SEARCH_TERM')
+    await sendAuditEvent('SEARCH_CLOSED_CASELIST', username, undefined, 'NOT_APPLICABLE', {
+      filter: requestedFilter.params,
+    })
 
     let closedCaseList = await this.accreditedProgrammesManageAndDeliverService.getClosedCaselist(
       username,

--- a/server/group/groupController.test.ts
+++ b/server/group/groupController.test.ts
@@ -44,8 +44,9 @@ describe('GroupController', () => {
           expect(sendAuditEvent).toHaveBeenCalledWith(
             'SEARCH_NOT_STARTED_OR_IN_PROGRESS_GROUP_LIST',
             'user1',
-            JSON.stringify({}),
-            'SEARCH_TERM',
+            undefined,
+            'NOT_APPLICABLE',
+            { filter: {} },
           )
         })
     })
@@ -102,8 +103,9 @@ describe('GroupController', () => {
           expect(sendAuditEvent).toHaveBeenCalledWith(
             'SEARCH_COMPLETED_GROUP_LIST',
             'user1',
-            JSON.stringify({}),
-            'SEARCH_TERM',
+            undefined,
+            'NOT_APPLICABLE',
+            { filter: {} },
           )
         })
     })

--- a/server/group/groupController.ts
+++ b/server/group/groupController.ts
@@ -28,12 +28,9 @@ export default class GroupController extends BaseController {
     const selectedTab = 'NOT_STARTED_OR_IN_PROGRESS'
 
     const requestedFilter = GroupListFilter.fromRequest(req)
-    await sendAuditEvent(
-      'SEARCH_NOT_STARTED_OR_IN_PROGRESS_GROUP_LIST',
-      username,
-      JSON.stringify(requestedFilter.params),
-      'SEARCH_TERM',
-    )
+    await sendAuditEvent('SEARCH_NOT_STARTED_OR_IN_PROGRESS_GROUP_LIST', username, undefined, 'NOT_APPLICABLE', {
+      filter: requestedFilter.params,
+    })
 
     let notStartedGroupList = await this.accreditedProgrammesManageAndDeliverService.getGroupList(
       username,
@@ -80,7 +77,9 @@ export default class GroupController extends BaseController {
     const selectedTab = 'COMPLETE'
 
     const requestedFilter = GroupListFilter.fromRequest(req)
-    await sendAuditEvent('SEARCH_COMPLETED_GROUP_LIST', username, JSON.stringify(requestedFilter.params), 'SEARCH_TERM')
+    await sendAuditEvent('SEARCH_COMPLETED_GROUP_LIST', username, undefined, 'NOT_APPLICABLE', {
+      filter: requestedFilter.params,
+    })
 
     let completedGroupList = await this.accreditedProgrammesManageAndDeliverService.getGroupList(
       username,

--- a/server/groupOverview/groupOverviewController.test.ts
+++ b/server/groupOverview/groupOverviewController.test.ts
@@ -39,13 +39,10 @@ describe('groupOverview', () => {
           expect(res.text).toContain(`Allocations and waitlist`)
         })
         .then(() => {
-          expect(sendAuditEvent).toHaveBeenCalledWith(
-            'SEARCH_GROUP_WAITLIST',
-            'user1',
-            JSON.stringify({}),
-            'SEARCH_TERM',
-            { groupId: '1234' },
-          )
+          expect(sendAuditEvent).toHaveBeenCalledWith('SEARCH_GROUP_WAITLIST', 'user1', undefined, 'NOT_APPLICABLE', {
+            groupId: '1234',
+            filter: {},
+          })
         })
     })
   })
@@ -61,13 +58,10 @@ describe('groupOverview', () => {
           expect(res.text).toContain(`Allocations and waitlist`)
         })
         .then(() => {
-          expect(sendAuditEvent).toHaveBeenCalledWith(
-            'SEARCH_GROUP_ALLOCATED',
-            'user1',
-            JSON.stringify({}),
-            'SEARCH_TERM',
-            { groupId: '1234' },
-          )
+          expect(sendAuditEvent).toHaveBeenCalledWith('SEARCH_GROUP_ALLOCATED', 'user1', undefined, 'NOT_APPLICABLE', {
+            groupId: '1234',
+            filter: {},
+          })
         })
     })
   })

--- a/server/groupOverview/groupOverviewController.ts
+++ b/server/groupOverview/groupOverviewController.ts
@@ -33,7 +33,10 @@ export default class GroupOverviewController extends BaseController {
     }
 
     const filter = GroupAllocationsFilter.fromRequest(req)
-    await sendAuditEvent('SEARCH_GROUP_ALLOCATED', username, JSON.stringify(filter.params), 'SEARCH_TERM', { groupId })
+    await sendAuditEvent('SEARCH_GROUP_ALLOCATED', username, undefined, 'NOT_APPLICABLE', {
+      groupId,
+      filter: filter.params,
+    })
 
     const groupOverview = await this.accreditedProgrammesManageAndDeliverService.getGroupAllocatedMembers(
       username,
@@ -88,7 +91,10 @@ export default class GroupOverviewController extends BaseController {
     }
 
     const filter = GroupAllocationsFilter.fromRequest(req)
-    await sendAuditEvent('SEARCH_GROUP_WAITLIST', username, JSON.stringify(filter.params), 'SEARCH_TERM', { groupId })
+    await sendAuditEvent('SEARCH_GROUP_WAITLIST', username, undefined, 'NOT_APPLICABLE', {
+      groupId,
+      filter: filter.params,
+    })
 
     const groupOverview = await this.accreditedProgrammesManageAndDeliverService.getGroupWaitlistMembers(
       username,

--- a/server/reporting/reportingController.test.ts
+++ b/server/reporting/reportingController.test.ts
@@ -91,8 +91,8 @@ describe('Reporting controller', () => {
     expect(sendAuditEvent).toHaveBeenCalledWith(
       'VIEW_DOSAGE_REPORT',
       'user1',
-      JSON.stringify({ referralsCreatedSince: '2026-05-21' }),
-      'SEARCH_TERM',
+      undefined,
+      'NOT_APPLICABLE',
       expect.objectContaining({ reportName: 'dosage', query: { referralsCreatedSince: '2026-05-21' } }),
     )
 
@@ -132,8 +132,8 @@ describe('Reporting controller', () => {
     expect(sendAuditEvent).toHaveBeenCalledWith(
       'VIEW_SESSION_RATE_REPORT',
       'user1',
-      JSON.stringify({ groupsStartedAfter: '2026-05-21' }),
-      'SEARCH_TERM',
+      undefined,
+      'NOT_APPLICABLE',
       expect.objectContaining({ reportName: 'session-rate', query: { groupsStartedAfter: '2026-05-21' } }),
     )
 
@@ -173,8 +173,8 @@ describe('Reporting controller', () => {
     expect(sendAuditEvent).toHaveBeenCalledWith(
       'VIEW_FACILITATOR_CONTINUITY_REPORT',
       'user1',
-      JSON.stringify({ groupsCreatedSince: '2026-05-21T12:00:00' }),
-      'SEARCH_TERM',
+      undefined,
+      'NOT_APPLICABLE',
       expect.objectContaining({
         reportName: 'facilitator-continuity',
         query: { groupsCreatedSince: '2026-05-21T12:00:00' },

--- a/server/reporting/reportingController.test.ts
+++ b/server/reporting/reportingController.test.ts
@@ -53,7 +53,13 @@ describe('Reporting controller', () => {
         expect(res.text).toBe(csv)
       })
 
-    expect(sendAuditEvent).toHaveBeenCalledWith('VIEW_GROUP_SIZE_REPORT', 'user1', '2026-05-18T13:30:00', 'SEARCH_TERM')
+    expect(sendAuditEvent).toHaveBeenCalledWith(
+      'VIEW_GROUP_SIZE_REPORT',
+      'user1',
+      undefined,
+      'NOT_APPLICABLE',
+      expect.objectContaining({ groupStartedSince: '2026-05-18T13:30:00' }),
+    )
     expect(accreditedProgrammesManageAndDeliverService.getGroupSizeReport).toHaveBeenCalledWith(
       'user1',
       '2026-05-18T13:30:00',

--- a/server/reporting/reportingController.ts
+++ b/server/reporting/reportingController.ts
@@ -68,7 +68,7 @@ export default class ReportingController {
     const { username } = req.user
     ReportingController.logReportRequest(req, 'group-size', { groupStartedSince })
 
-    await sendAuditEvent('VIEW_GROUP_SIZE_REPORT', username, groupStartedSince, 'SEARCH_TERM')
+    await sendAuditEvent('VIEW_GROUP_SIZE_REPORT', username, undefined, 'NOT_APPLICABLE', { groupStartedSince })
 
     const { csv, headers } = await this.accreditedProgrammesManageAndDeliverService.getGroupSizeReport(
       username,

--- a/server/reporting/reportingController.ts
+++ b/server/reporting/reportingController.ts
@@ -107,7 +107,7 @@ export default class ReportingController {
     const { username } = req.user
     ReportingController.logReportRequest(req, 'dosage', query)
 
-    await sendAuditEvent('VIEW_DOSAGE_REPORT', username, JSON.stringify(query), 'SEARCH_TERM', {
+    await sendAuditEvent('VIEW_DOSAGE_REPORT', username, undefined, 'NOT_APPLICABLE', {
       reportName: 'dosage',
       query,
     })
@@ -146,7 +146,7 @@ export default class ReportingController {
     const { username } = req.user
     ReportingController.logReportRequest(req, 'session-rate', query)
 
-    await sendAuditEvent('VIEW_SESSION_RATE_REPORT', username, JSON.stringify(query), 'SEARCH_TERM', {
+    await sendAuditEvent('VIEW_SESSION_RATE_REPORT', username, undefined, 'NOT_APPLICABLE', {
       reportName: 'session-rate',
       query,
     })
@@ -201,7 +201,7 @@ export default class ReportingController {
     const { username } = req.user
     ReportingController.logReportRequest(req, 'facilitator-continuity', query)
 
-    await sendAuditEvent('VIEW_FACILITATOR_CONTINUITY_REPORT', username, JSON.stringify(query), 'SEARCH_TERM', {
+    await sendAuditEvent('VIEW_FACILITATOR_CONTINUITY_REPORT', username, undefined, 'NOT_APPLICABLE', {
       reportName: 'facilitator-continuity',
       query,
     })


### PR DESCRIPTION
Audit team reported that SEARCH_NOT_STARTED_OR_IN_PROGRESS_GROUP_LIST audit was DLQing due to the subject id being invalid. Json strings have been moved to details to fix this. Issue appears to be due to maxlength limit for the subject id looking at the errors inside the audit team app insight logs