### PR TITLE
Apg 1918/probation practiitioner null fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
      - SERVICES_NDELIUS_INTEGRATION_API_BASE_URL=http://wiremock:8080
      - SERVICES_OASYS_API_BASE_URL=http://wiremock:8080
      - SERVICES_ASSESS_RISKS_AND_NEEDS_API_BASE_URL=http://wiremock:8080
+     - PROBATION_ACCESS_CONTROL_API_BASE_URL=http://wiremock:8080
      #      - API_CLIENT_SECRET=${API_CLIENT_SECRET}
      # JVM debug options
      - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,6 @@ services:
      - SERVICES_NDELIUS_INTEGRATION_API_BASE_URL=http://wiremock:8080
      - SERVICES_OASYS_API_BASE_URL=http://wiremock:8080
      - SERVICES_ASSESS_RISKS_AND_NEEDS_API_BASE_URL=http://wiremock:8080
-     - PROBATION_ACCESS_CONTROL_API_BASE_URL=http://wiremock:8080
      #      - API_CLIENT_SECRET=${API_CLIENT_SECRET}
      # JVM debug options
      - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005

--- a/server/referralDetails/referralDetailsPresenter.ts
+++ b/server/referralDetails/referralDetailsPresenter.ts
@@ -86,7 +86,9 @@ export default class ReferralDetailsPresenter extends ReferralLayoutPresenter {
       },
       {
         key: 'Probation practitioner',
-        lines: [`${this.referralDetails.probationPractitionerName}`],
+        lines: this.referralDetails.probationPractitionerName
+          ? [this.referralDetails.probationPractitionerName]
+          : ['No information available'],
       },
       {
         key: 'Probation practitioner email address',


### PR DESCRIPTION
Where there is no practitioner name, 'No information available' will be displayed instead of 'null'.


<img width="825" height="379" alt="Screenshot 2026-08-03 at 14 15 45" src="https://github.com/user-attachments/assets/39682829-89a4-4c79-add2-2865d122cd59" />
