### PR TITLE
APG*2441 Remove PNI warning referencing OGRS3 risk scores from PNI view

### DIFF
--- a/server/views/pni/pni.njk
+++ b/server/views/pni/pni.njk
@@ -15,14 +15,6 @@
             {% if presenter.isCohortUpdated %}
               {{ mojAlert(presenter.cohortUpdatedSuccessMessageArgs) }}
             {% endif %}
-            {{ mojAlert({
-             variant: "warning",
-             title: "The pathway shown here is currently based on OGRS3 risk scores",
-             showTitleAsHeading: true,
-             dismissible: false,
-             html: '<p>The recommended pathway shown here is based on the old risk predictors (OGRS3). If this person’s risk scores use the new predictors (OGRS4), referrers or programme teams should calculate the recommended pathway manually.</p>
-                    <p>Following the instructions in the Needs and Suitability guide, use the PNI scores under ‘How is this calculated?’ and the risk scores in this service or OASys to calculate this.</p>'
-            }) }}
             {% if presenter.isLdcUpdated %}
               {{ mojAlert(presenter.ldcUpdatedSuccessMessageArgs) }}
             {% endif %}


### PR DESCRIPTION
This pull request removes the PNI warning message that referenced OGRS3 risk scores from the PNI view. 